### PR TITLE
TLS 1.3 support for Android < 10

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -248,6 +248,9 @@ dependencies {
     implementation("info.debatty:java-string-similarity:1.2.1")
 
     implementation("com.google.android.gms:play-services-oss-licenses:${Versions.OSS_LICENSE}")
+
+    // TLS 1.3 support for Android < 10
+    implementation("org.conscrypt:conscrypt-android:2.4.0")
 }
 
 

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi
 import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
+import android.os.Build
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
@@ -16,11 +17,13 @@ import eu.kanade.tachiyomi.ui.security.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.system.LocaleHelper
 import org.acra.ACRA
 import org.acra.annotation.ReportsCrashes
+import org.conscrypt.Conscrypt
 import timber.log.Timber
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.InjektScope
 import uy.kohesive.injekt.injectLazy
 import uy.kohesive.injekt.registry.default.DefaultRegistrar
+import java.security.Security
 
 @ReportsCrashes(
         formUri = "https://collector.tracepot.com/e90773ff",
@@ -34,6 +37,11 @@ open class App : Application(), LifecycleObserver {
     override fun onCreate() {
         super.onCreate()
         if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+
+        // TLS 1.3 support for Android 10 and below
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Security.insertProviderAt(Conscrypt.newProvider(), 1)
+        }
 
         Injekt = InjektScope(DefaultRegistrar())
         Injekt.importModule(AppModule(this))


### PR DESCRIPTION
Fix https://github.com/inorichi/tachiyomi-extensions/issues/3233.

Cheery-picked from arkon@31015504f4d0df3d0a4b185fb754f1224dfe1c0c, and changed to Kotlin version.