### PR TITLE
Use Tachiyomiorg version of subsampling-scale-image-view

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,7 +87,7 @@ androidExtensions {
 
 dependencies {
     // Modified dependencies
-    implementation("com.github.jays2kings:subsampling-scale-image-view:78f9664")
+    implementation("com.github.tachiyomiorg:subsampling-scale-image-view:6caf219")
     implementation("com.github.inorichi:junrar-android:634c1f5")
 
     // Android X libraries


### PR DESCRIPTION
I pulled your fork's changes into the "main fork": https://github.com/tachiyomiorg/subsampling-scale-image-view/commits/tachiyomi

This version also includes some stuff like bumped up minSdk, some updated image libs, etc.