### PR TITLE
Adding Default categorie in global update pref

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsLibraryController.kt
@@ -143,10 +143,14 @@ class SettingsLibraryController : SettingsController() {
             multiSelectListPreferenceMat(activity) {
                 key = Keys.libraryUpdateCategories
                 titleRes = R.string.categories_to_include_in_global_update
-                entries = dbCategories.map { it.name }
-                entryValues = dbCategories.map { it.id.toString() }
+
+                val categories = listOf(Category.createDefault(context)) + dbCategories
+                entries = categories.map { it.name }
+                entryValues = categories.map { it.id.toString() }
+
                 allSelectionRes = R.string.all
             }
+
             intListPreference(activity) {
                 key = Keys.updateOnRefresh
                 titleRes = R.string.categories_on_manual


### PR DESCRIPTION
I added the default category in the library preference "Categories to include in global update".
In my case I wanted to be able to create a category that won't update automatically. But it was not possible to only choose the default category for the global update.

![image](https://user-images.githubusercontent.com/55888232/115131328-96c28100-9ff7-11eb-9bfc-dd3225f95852.png)