### PR TITLE
Sanitize manga title in page download subfolder name

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -726,7 +726,7 @@ class ReaderPresenter(
             File.separator + Environment.DIRECTORY_PICTURES +
             File.separator + context.getString(R.string.app_name)
         val destDir = if (preferences.folderPerManga()) {
-            File(baseDir + File.separator + manga.title)
+            File(baseDir + File.separator + DiskUtil.buildValidFilename(manga.title))
         } else {
             File(baseDir)
         }


### PR DESCRIPTION
The option to save pages to separate subfolders based on manga title didn't sanitize the manga title in the subfolders' names, which made it impossible to save pages from manga with reserved characters in their titles with the option enabled. This commit aims to fix that by using DiskUtil.buildValidFilename to sanitize it.

Note: The commit in this PR is cherry-picked from the upstream Tachiyomi repository. I'm fairly new to Git and this is the cleanest way I could find to integrate my changes into this fork as well.