### PR TITLE
fix downloading filtered out chapters

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -32,7 +32,7 @@ fun syncChaptersWithSource(
     }
 
     val downloadManager: DownloadManager = Injekt.get()
-
+    val chapterFilter: ChapterFilter = Injekt.get()
     // Chapters from db.
     val dbChapters = db.getChapters(manga).executeAsBlocking()
 
@@ -161,8 +161,10 @@ fun syncChaptersWithSource(
         } else manga.last_update = newestChapterDate
         db.updateLastUpdated(manga).executeAsBlocking()
     }
-
-    return Pair(toAdd.subtract(readded).toList(), toDelete - readded)
+    return Pair(
+        chapterFilter.filterChaptersByScanlators(toAdd.subtract(readded).toList(), manga),
+        toDelete - readded
+    )
 }
 
 // checks if the chapter in db needs updated


### PR DESCRIPTION
fixes issue that @CarlosEsco mentioned in #1006 

chapter 5 and 6 is new chapters
chapter 5 is hidden by filter and chapter 6 is not.


video of testing

https://user-images.githubusercontent.com/57241064/134711409-e79a2e77-e0d7-41dd-8348-175d3dfb586d.mp4



possible issues that may need addressed:
I tested if you download a chapter and then hide it with the filter and the source deletes that chapter, the chapter will become orphaned. I previously had the 2nd pair, `toDelete - readded` filtered as well, and thought not filtering it would alleviate issue but it did not and have left it alone. 
