### PR TITLE
compress to cbz after downloading

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -85,7 +85,7 @@ class DownloadCache(
 
         val files = mangaFiles[manga.id]?.toHashSet() ?: return false
         return provider.getValidChapterDirNames(chapter).any {
-            it in files
+            it in files || "$it.cbz" in files
         }
     }
 
@@ -153,7 +153,7 @@ class DownloadCache(
 
             val mangaDirs = sourceDir.dir.listFiles().orEmpty().mapNotNull { mangaDir ->
                 val name = mangaDir.name ?: return@mapNotNull null
-                val chapterDirs = mangaDir.listFiles().orEmpty().mapNotNull { chapterFile -> chapterFile.name }.toHashSet()
+                val chapterDirs = mangaDir.listFiles().orEmpty().mapNotNull { chapterFile -> chapterFile.name?.replace("cbz", "") }.toHashSet()
                 name to MangaDirectory(mangaDir, chapterDirs)
             }.toMap()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadCache.kt
@@ -153,7 +153,7 @@ class DownloadCache(
 
             val mangaDirs = sourceDir.dir.listFiles().orEmpty().mapNotNull { mangaDir ->
                 val name = mangaDir.name ?: return@mapNotNull null
-                val chapterDirs = mangaDir.listFiles().orEmpty().mapNotNull { chapterFile -> chapterFile.name?.replace("cbz", "") }.toHashSet()
+                val chapterDirs = mangaDir.listFiles().orEmpty().mapNotNull { chapterFile -> chapterFile.name?.replace(".cbz", "") }.toHashSet()
                 name to MangaDirectory(mangaDir, chapterDirs)
             }.toMap()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -255,7 +255,7 @@ class DownloadManager(val context: Context) {
                     chapters,
                     manga,
                     source
-                ) + provider.findCBZFiles(chapters, manga, source)
+                )
             chapterDirs.forEach { it.delete() }
             cache.removeChapters(chapters, manga)
             if (cache.getDownloadCount(manga, true) == 0) { // Delete manga directory if empty

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadManager.kt
@@ -255,7 +255,7 @@ class DownloadManager(val context: Context) {
                     chapters,
                     manga,
                     source
-                )
+                ) + provider.findCBZFiles(chapters, manga, source)
             chapterDirs.forEach { it.delete() }
             cache.removeChapters(chapters, manga)
             if (cache.getDownloadCount(manga, true) == 0) { // Delete manga directory if empty

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -204,10 +204,6 @@ class DownloadProvider(private val context: Context) {
         val mangaDir = findMangaDir(manga, source) ?: return emptyList()
         return chapters.mapNotNull { mangaDir.findFile("${getChapterDirName(it)}_tmp") }
     }
-    fun findCBZFiles(chapters: List<Chapter>, manga: Manga, source: Source): List<UniFile> {
-        val mangaDir = findMangaDir(manga, source) ?: return emptyList()
-        return chapters.mapNotNull { mangaDir.findFile("${getChapterDirName(it)}.cbz") }
-    }
 
     /**
      * Returns the download directory name for a source.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -199,6 +199,10 @@ class DownloadProvider(private val context: Context) {
         val mangaDir = findMangaDir(manga, source) ?: return emptyList()
         return chapters.mapNotNull { mangaDir.findFile("${getChapterDirName(it)}_tmp") }
     }
+    fun findCBZFiles(chapters: List<Chapter>, manga: Manga, source: Source): List<UniFile> {
+        val mangaDir = findMangaDir(manga, source) ?: return emptyList()
+        return chapters.mapNotNull { mangaDir.findFile("${getChapterDirName(it)}.cbz") }
+    }
 
     /**
      * Returns the download directory name for a source.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -88,7 +88,7 @@ class DownloadProvider(private val context: Context) {
     fun findChapterDir(chapter: Chapter, manga: Manga, source: Source): UniFile? {
         val mangaDir = findMangaDir(manga, source)
         return getValidChapterDirNames(chapter).asSequence()
-            .mapNotNull { mangaDir?.findFile(it, true) }
+            .mapNotNull { mangaDir?.findFile(it, true) ?: mangaDir?.findFile("$it.cbz", true) }
             .firstOrNull()
     }
 
@@ -175,6 +175,10 @@ class DownloadProvider(private val context: Context) {
                 if (scanalatorNameHashSet.contains(fileName)) {
                     return@filter false
                 }
+                if (fileName.endsWith(".cbz")) {
+                    return@filter true
+                }
+
                 val afterScanlatorCheck = fileName.substringAfter("_")
                 // check both these dont exist because who knows how a chapter name is and it might not trim scanlator correctly
                 return@filter !chapterNameHashSet.contains(fileName) && !chapterNameHashSet.contains(afterScanlatorCheck)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt
@@ -103,10 +103,14 @@ class DownloadProvider(private val context: Context) {
         val mangaDir = findMangaDir(manga, source) ?: return emptyList()
         val chapterNameHashSet = chapters.map { it.name }.toHashSet()
         val scanalatorNameHashSet = chapters.map { getChapterDirName(it) }.toHashSet()
+        val scanalatorCbzNameHashSet = chapters.map { "${getChapterDirName(it)}.cbz" }.toHashSet()
 
         return mangaDir.listFiles()!!.asList().filter { file ->
             file.name?.let { fileName ->
                 if (scanalatorNameHashSet.contains(fileName)) {
+                    return@filter true
+                }
+                if (scanalatorCbzNameHashSet.contains(fileName)) {
                     return@filter true
                 }
                 val afterScanlatorCheck = fileName.substringAfter("_")
@@ -165,6 +169,7 @@ class DownloadProvider(private val context: Context) {
         val mangaDir = findMangaDir(manga, source) ?: return emptyList()
         val chapterNameHashSet = chapters.map { it.name }.toHashSet()
         val scanalatorNameHashSet = chapters.map { getChapterDirName(it) }.toHashSet()
+        val scanalatorCbzNameHashSet = chapters.map { "${getChapterDirName(it)}.cbz" }.toHashSet()
 
         return mangaDir.listFiles()!!.asList().filter { file ->
             file.name?.let { fileName ->
@@ -175,8 +180,8 @@ class DownloadProvider(private val context: Context) {
                 if (scanalatorNameHashSet.contains(fileName)) {
                     return@filter false
                 }
-                if (fileName.endsWith(".cbz")) {
-                    return@filter true
+                if (scanalatorCbzNameHashSet.contains(fileName)) {
+                    return@filter false
                 }
 
                 val afterScanlatorCheck = fileName.substringAfter("_")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -532,24 +532,18 @@ class Downloader(
             if (preferences.saveChaptersAsCBZ().get()) {
                 val zip = mangaDir.createFile("$dirname.cbz.tmp")
                 val zipOut = ZipOutputStream(BufferedOutputStream(zip.openOutputStream()))
-                val compressionLevel = preferences.saveChaptersAsCBZLevel().get()
+                zipOut.setMethod(ZipEntry.STORED)
 
-                zipOut.setLevel(compressionLevel)
-                if (compressionLevel == 0) {
-                    zipOut.setMethod(ZipEntry.STORED)
-                }
                 tmpDir.listFiles()?.forEach { img ->
                     val input = img.openInputStream()
                     val data = input.readBytes()
                     val entry = ZipEntry(img.name)
-                    if (compressionLevel == 0) {
-                        val crc = CRC32()
-                        val size = img.length()
-                        crc.update(data)
-                        entry.crc = crc.value
-                        entry.compressedSize = size
-                        entry.size = size
-                    }
+                    val crc = CRC32()
+                    val size = img.length()
+                    crc.update(data)
+                    entry.crc = crc.value
+                    entry.compressedSize = size
+                    entry.size = size
                     zipOut.putNextEntry(entry)
                     zipOut.write(data)
                     input.close()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.data.download.model.Download
 import eu.kanade.tachiyomi.data.download.model.DownloadQueue
 import eu.kanade.tachiyomi.data.library.LibraryUpdateService
 import eu.kanade.tachiyomi.data.library.PER_SOURCE_QUEUE_WARNING_THRESHOLD
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.online.HttpSource
@@ -37,7 +38,11 @@ import rx.schedulers.Schedulers
 import rx.subscriptions.CompositeSubscription
 import timber.log.Timber
 import uy.kohesive.injekt.injectLazy
+import java.io.BufferedOutputStream
 import java.io.File
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 
 /**
  * This class is the one in charge of downloading chapters.
@@ -59,7 +64,7 @@ class Downloader(
     private val cache: DownloadCache,
     private val sourceManager: SourceManager
 ) {
-
+    private val preferences: PreferencesHelper by injectLazy()
     private val chapterCache: ChapterCache by injectLazy()
 
     /**
@@ -524,9 +529,39 @@ class Downloader(
 
         // Only rename the directory if it's downloaded.
         if (download.status == Download.State.DOWNLOADED) {
-            tmpDir.renameTo(dirname)
-            cache.addChapter(dirname, download.manga)
+            val test = true
+            if (test == true) {
+                val zip = mangaDir.createFile("$dirname.cbz.tmp")
+                val zipOut = ZipOutputStream(BufferedOutputStream(zip.openOutputStream()))
+                val compressionLevel = preferences.saveChaptersAsCBZLevel().get()
 
+                zipOut.setLevel(compressionLevel)
+                if (compressionLevel == 0) {
+                    zipOut.setMethod(ZipEntry.STORED)
+                }
+                tmpDir.listFiles()?.forEach { img ->
+                    val input = img.openInputStream()
+                    val data = input.readBytes()
+                    val entry = ZipEntry(img.name)
+                    if (compressionLevel == 0) {
+                        val crc = CRC32()
+                        val size = img.length()
+                        crc.update(data)
+                        entry.crc = crc.value
+                        entry.compressedSize = size
+                        entry.size = size
+                    }
+                    zipOut.putNextEntry(entry)
+                    zipOut.write(data)
+                    input.close()
+                }
+                zipOut.close()
+                zip.renameTo("$dirname.cbz")
+                tmpDir.delete()
+            } else {
+                tmpDir.renameTo(dirname)
+            }
+            cache.addChapter(dirname, download.manga)
             DiskUtil.createNoMediaFile(tmpDir, context)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -529,8 +529,7 @@ class Downloader(
 
         // Only rename the directory if it's downloaded.
         if (download.status == Download.State.DOWNLOADED) {
-            val test = true
-            if (test == true) {
+            if (preferences.saveChaptersAsCBZ().get()) {
                 val zip = mangaDir.createFile("$dirname.cbz.tmp")
                 val zipOut = ZipOutputStream(BufferedOutputStream(zip.openOutputStream()))
                 val compressionLevel = preferences.saveChaptersAsCBZLevel().get()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -257,6 +257,10 @@ object PreferenceKeys {
 
     const val chaptersDescAsDefault = "chapters_desc_as_default"
 
+    const val saveChaptersAsCBZ = "save_chapter_as_cbz"
+
+    const val saveChaptersAsCBZLevel = "save_chapter_as_cbz_level"
+
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -259,8 +259,6 @@ object PreferenceKeys {
 
     const val saveChaptersAsCBZ = "save_chapter_as_cbz"
 
-    const val saveChaptersAsCBZLevel = "save_chapter_as_cbz_level"
-
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -299,6 +299,10 @@ class PreferencesHelper(val context: Context) {
 
     fun downloadNew() = flowPrefs.getBoolean(Keys.downloadNew, false)
 
+    fun saveChaptersAsCBZ() = flowPrefs.getBoolean(Keys.saveChaptersAsCBZ, false)
+
+    fun saveChaptersAsCBZLevel() = flowPrefs.getInt(Keys.saveChaptersAsCBZLevel, 0)
+
     fun downloadNewCategories() = flowPrefs.getStringSet(Keys.downloadNewCategories, emptySet())
     fun downloadNewCategoriesExclude() = flowPrefs.getStringSet(Keys.downloadNewCategoriesExclude, emptySet())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -301,8 +301,6 @@ class PreferencesHelper(val context: Context) {
 
     fun saveChaptersAsCBZ() = flowPrefs.getBoolean(Keys.saveChaptersAsCBZ, false)
 
-    fun saveChaptersAsCBZLevel() = flowPrefs.getInt(Keys.saveChaptersAsCBZLevel, 0)
-
     fun downloadNewCategories() = flowPrefs.getStringSet(Keys.downloadNewCategories, emptySet())
     fun downloadNewCategoriesExclude() = flowPrefs.getStringSet(Keys.downloadNewCategoriesExclude, emptySet())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/loader/DownloadPageLoader.kt
@@ -4,12 +4,17 @@ import android.app.Application
 import android.net.Uri
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.download.DownloadProvider
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderChapter
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.util.lang.compareToCaseInsensitiveNaturalOrder
+import eu.kanade.tachiyomi.util.system.ImageUtil
 import rx.Observable
 import uy.kohesive.injekt.injectLazy
+import java.io.File
+import java.util.zip.ZipFile
 
 /**
  * Loader used to load a chapter from the downloaded chapters.
@@ -25,26 +30,58 @@ class DownloadPageLoader(
      * The application context. Needed to open input streams.
      */
     private val context by injectLazy<Application>()
+    private val downloadProvider by lazy { DownloadProvider(context) }
 
     /**
      * Returns an observable containing the pages found on this downloaded chapter.
      */
     override fun getPages(): Observable<List<ReaderPage>> {
-        return downloadManager.buildPageList(source, manga, chapter.chapter)
-            .map { pages ->
-                pages.map { page ->
-                    ReaderPage(
-                        page.index,
-                        page.url,
-                        page.imageUrl,
-                        {
-                            context.contentResolver.openInputStream(page.uri ?: Uri.EMPTY)!!
+        val chapterPath = downloadProvider.findChapterDir(chapter.chapter, manga, source)
+        if (chapterPath?.isFile == true) {
+            val zip = if (!File(chapterPath.filePath!!).canRead()) {
+                val tmpFile = File.createTempFile(chapterPath.name!!.replace(".cbz", ""), ".cbz")
+                val buffer = ByteArray(1024)
+                chapterPath.openInputStream().use { input ->
+                    tmpFile.outputStream().use { fileOut ->
+                        while (true) {
+                            val length = input.read(buffer)
+                            if (length <= 0) break
+                            fileOut.write(buffer, 0, length)
                         }
-                    ).apply {
+                        fileOut.flush()
+                    }
+                }
+                ZipFile(tmpFile.absolutePath)
+            } else ZipFile(chapterPath.filePath)
+            return zip.entries().toList()
+                .filter { !it.isDirectory && ImageUtil.isImage(it.name) { zip.getInputStream(it) } }
+                .sortedWith { f1, f2 -> f1.name.compareToCaseInsensitiveNaturalOrder(f2.name) }
+                .mapIndexed { i, entry ->
+                    val streamFn = { zip.getInputStream(entry) }
+                    ReaderPage(i).apply {
+                        stream = streamFn
                         status = Page.READY
                     }
                 }
-            }
+                .let { Observable.just(it) }
+        } else {
+            return downloadManager.buildPageList(source, manga, chapter.chapter)
+                .map { pages ->
+                    pages.map { page ->
+                        ReaderPage(
+                            page.index,
+                            page.url,
+                            page.imageUrl,
+
+                            {
+                                context.contentResolver.openInputStream(page.uri ?: Uri.EMPTY)!!
+                            }
+                        ).apply {
+                            status = Page.READY
+                        }
+                    }
+                }
+        }
     }
 
     override fun getPage(page: ReaderPage): Observable<Int> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -14,11 +14,9 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
-import eu.kanade.tachiyomi.data.preference.asImmediateFlow
 import eu.kanade.tachiyomi.data.preference.asImmediateFlowIn
 import eu.kanade.tachiyomi.util.system.getFilePicker
 import eu.kanade.tachiyomi.util.system.withOriginalWidth
-import kotlinx.coroutines.flow.launchIn
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -48,6 +46,11 @@ class SettingsDownloadController : SettingsController() {
             key = Keys.downloadOnlyOverWifi
             titleRes = R.string.only_download_over_wifi
             defaultValue = true
+        }
+        switchPreference {
+            key = Keys.saveChaptersAsCBZ
+            titleRes = R.string.save_chapters_as_cbz
+            defaultValue = false
         }
         preferenceCategory {
             titleRes = R.string.remove_after_read
@@ -108,25 +111,6 @@ class SettingsDownloadController : SettingsController() {
                     )
                     entryRange = 0..2
                     defaultValue = 0
-                }
-            }
-            preferenceCategory {
-                titleRes = R.string.save_chapters_as_cbz
-
-                switchPreference {
-                    key = Keys.saveChaptersAsCBZ
-                    titleRes = R.string.save_chapters_as_cbz
-                    defaultValue = false
-                }
-
-                intListPreference(activity) {
-                    key = Keys.saveChaptersAsCBZLevel
-                    titleRes = R.string.cbz_compression_level
-                    entries = (0..9).map { it.toString() }
-                    entryRange = 0..9
-                    defaultValue = 0
-                    preferences.saveChaptersAsCBZ().asImmediateFlow { isVisible = it }
-                        .launchIn(viewScope)
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -14,9 +14,11 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
+import eu.kanade.tachiyomi.data.preference.asImmediateFlow
 import eu.kanade.tachiyomi.data.preference.asImmediateFlowIn
 import eu.kanade.tachiyomi.util.system.getFilePicker
 import eu.kanade.tachiyomi.util.system.withOriginalWidth
+import kotlinx.coroutines.flow.launchIn
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -106,6 +108,25 @@ class SettingsDownloadController : SettingsController() {
                     )
                     entryRange = 0..2
                     defaultValue = 0
+                }
+            }
+            preferenceCategory {
+                titleRes = R.string.save_chapters_as_cbz
+
+                switchPreference {
+                    key = Keys.saveChaptersAsCBZ
+                    titleRes = R.string.save_chapters_as_cbz
+                    defaultValue = false
+                }
+
+                intListPreference(activity) {
+                    key = Keys.saveChaptersAsCBZLevel
+                    titleRes = R.string.cbz_compression_level
+                    entries = listOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
+                    entryRange = 0..10
+                    defaultValue = 0
+                    preferences.saveChaptersAsCBZ().asImmediateFlow { isVisible = it }
+                        .launchIn(viewScope)
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -122,8 +122,8 @@ class SettingsDownloadController : SettingsController() {
                 intListPreference(activity) {
                     key = Keys.saveChaptersAsCBZLevel
                     titleRes = R.string.cbz_compression_level
-                    entries = listOf("0", "1", "2", "3", "4", "5", "6", "7", "8", "9")
-                    entryRange = 0..10
+                    entries = (0..9).map { it.toString() }
+                    entryRange = 0..9
                     defaultValue = 0
                     preferences.saveChaptersAsCBZ().asImmediateFlow { isVisible = it }
                         .launchIn(viewScope)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -894,6 +894,8 @@
     <string name="always_keep">Always keep</string>
     <string name="always_delete">Always delete</string>
     <string name="automatic_removal">Automatic removal</string>
+    <string name="save_chapters_as_cbz">Save chapters as CBZ</string>
+    <string name="cbz_compression_level">CBZ compression level</string>
 
     <!-- Time -->
     <string name="manual">Manual</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -895,7 +895,6 @@
     <string name="always_delete">Always delete</string>
     <string name="automatic_removal">Automatic removal</string>
     <string name="save_chapters_as_cbz">Save chapters as CBZ</string>
-    <string name="cbz_compression_level">CBZ compression level</string>
 
     <!-- Time -->
     <string name="manual">Manual</string>


### PR DESCRIPTION
Since I screwed up the last PR, I'm opening a new one...

Things tested:
-  Download and convert folder to cbz
-  Able to read cbz both online and offline
-  delete cbz when button is used and also in the top button
-  correctly show that download is deleted afterwards
- cleanup downloads correctly deletes file if orphaned and doesn't delete it if not orphaned
- download cache recognizes it with force refresh setting or restarting of app

I also agree with Carlos and removed the cbz compression level but we can easily add it back in if you want it.

~~Things that I noticed when playing around is that the cleanup downloads deletes all cbz downloads and I'm pretty sure its because I added [this](https://github.com/Seishirou101/tachiyomiJ2K/blob/9511786f8b545893215ca49f0d363d19271ebb11/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadProvider.kt#L178) and if the cbz exists but the cache doesn't recognize it being downloaded, you can't redownload it or force it to recognize it being download. So the download cache recognizing logic needs to change I think.~~

~~So when I have time again I'll see if I can figure those out...~~

Figured them out, whether it is optimal or redundant is... lol but they work!
