### PR TITLE
Add required changes for extensions-lib 1.3

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/AppInfo.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/AppInfo.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi
+
+/**
+ * Used by extensions.
+ *
+ * @since extension-lib 1.3
+ */
+object AppInfo {
+    fun getVersionCode() = BuildConfig.VERSION_CODE
+    fun getVersionName() = BuildConfig.VERSION_NAME
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonParser
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.await
-import eu.kanade.tachiyomi.network.interceptor.RateLimitInterceptor
+import eu.kanade.tachiyomi.network.interceptor.rateLimit
 import eu.kanade.tachiyomi.network.jsonMime
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -28,7 +28,7 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
 
     private val authClient = client.newBuilder()
         .addInterceptor(interceptor)
-        .addInterceptor(RateLimitInterceptor(85, 1, TimeUnit.MINUTES))
+        .rateLimit(85, 1, TimeUnit.MINUTES)
         .build()
 
     suspend fun addLibManga(track: Track): Track {

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionLoader.kt
@@ -36,7 +36,7 @@ internal object ExtensionLoader {
     private const val METADATA_SOURCE_FACTORY = "tachiyomi.extension.factory"
     private const val METADATA_NSFW = "tachiyomi.extension.nsfw"
     const val LIB_VERSION_MIN = 1.2
-    const val LIB_VERSION_MAX = 1.2
+    const val LIB_VERSION_MAX = 1.3
 
     private const val PACKAGE_FLAGS = PackageManager.GET_CONFIGURATIONS or PackageManager.GET_SIGNATURES
 

--- a/app/src/main/java/eu/kanade/tachiyomi/network/interceptor/RateLimitInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/interceptor/RateLimitInterceptor.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.network.interceptor
 
 import android.os.SystemClock
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
 
@@ -13,14 +14,22 @@ import java.util.concurrent.TimeUnit
  * permits = 5,  period = 1, unit = seconds  =>  5 requests per second
  * permits = 10, period = 2, unit = minutes  =>  10 requests per 2 minutes
  *
+ * @since extension-lib 1.3
+ *
  * @param permits {Int}   Number of requests allowed within a period of units.
  * @param period {Long}   The limiting duration. Defaults to 1.
  * @param unit {TimeUnit} The unit of time for the period. Defaults to seconds.
  */
-class RateLimitInterceptor(
+fun OkHttpClient.Builder.rateLimit(
+    permits: Int,
+    period: Long = 1,
+    unit: TimeUnit = TimeUnit.SECONDS,
+) = addInterceptor(RateLimitInterceptor(permits, period, unit))
+
+private class RateLimitInterceptor(
     private val permits: Int,
-    private val period: Long = 1,
-    private val unit: TimeUnit = TimeUnit.SECONDS
+    period: Long,
+    unit: TimeUnit,
 ) : Interceptor {
 
     private val requestQueue = ArrayList<Long>(permits)

--- a/app/src/main/java/eu/kanade/tachiyomi/network/interceptor/SpecificHostRateLimitInterceptor.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/network/interceptor/SpecificHostRateLimitInterceptor.kt
@@ -3,6 +3,7 @@ package eu.kanade.tachiyomi.network.interceptor
 import android.os.SystemClock
 import okhttp3.HttpUrl
 import okhttp3.Interceptor
+import okhttp3.OkHttpClient
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
 
@@ -14,17 +15,25 @@ import java.util.concurrent.TimeUnit
  * httpUrl = "api.manga.com".toHttpUrlOrNull(), permits = 5, period = 1, unit = seconds  =>  5 requests per second to api.manga.com
  * httpUrl = "imagecdn.manga.com".toHttpUrlOrNull(), permits = 10, period = 2, unit = minutes  =>  10 requests per 2 minutes to imagecdn.manga.com
  *
+ * @since extension-lib 1.3
+ *
  * @param httpUrl {HttpUrl} The url host that this interceptor should handle. Will get url's host by using HttpUrl.host()
  * @param permits {Int}   Number of requests allowed within a period of units.
  * @param period {Long}   The limiting duration. Defaults to 1.
  * @param unit {TimeUnit} The unit of time for the period. Defaults to seconds.
  */
-@Suppress("unused")
+fun OkHttpClient.Builder.rateLimitHost(
+    httpUrl: HttpUrl,
+    permits: Int,
+    period: Long = 1,
+    unit: TimeUnit = TimeUnit.SECONDS,
+) = addInterceptor(SpecificHostRateLimitInterceptor(httpUrl, permits, period, unit))
+
 class SpecificHostRateLimitInterceptor(
-    private val httpUrl: HttpUrl,
+    httpUrl: HttpUrl,
     private val permits: Int,
-    private val period: Long = 1,
-    private val unit: TimeUnit = TimeUnit.SECONDS
+    period: Long,
+    unit: TimeUnit,
 ) : Interceptor {
 
     private val requestQueue = ArrayList<Long>(permits)

--- a/app/src/main/java/eu/kanade/tachiyomi/source/UnmeteredSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/UnmeteredSource.kt
@@ -1,0 +1,8 @@
+package eu.kanade.tachiyomi.source
+
+/**
+ * A source that explicitly doesn't require traffic considerations.
+ *
+ * This typically applies for self-hosted sources.
+ */
+interface UnmeteredSource

--- a/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/model/SManga.kt
@@ -70,6 +70,9 @@ interface SManga : Serializable {
         const val ONGOING = 1
         const val COMPLETED = 2
         const val LICENSED = 3
+        const val PUBLISHING_FINISHED = 4
+        const val CANCELLED = 5
+        const val ON_HIATUS = 6
 
         fun create(): SManga {
             return MangaImpl()


### PR DESCRIPTION
Relevant extensions change: https://github.com/tachiyomiorg/tachiyomi-extensions/pull/11298

All lib changes: https://github.com/tachiyomiorg/extensions-lib/compare/1.2...1.3.0

This is the bare minimum to ensure J2K can load 1.3.x extensions. Of note, it doesn't do anything with the added `UnmeteredSource` interface nor show proper strings for the new manga statuses.