### PR TITLE
Remove color tint when using a physical input device to navigate

### DIFF
--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -11,7 +11,8 @@
     <FrameLayout
         android:id="@+id/viewer_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:descendantFocusability="blocksDescendants" />
 
     <ProgressBar
         android:id="@+id/please_wait"


### PR DESCRIPTION
This fixes #1200, #1203 and #927 by preventing the reader view from being focused when using a physical input device by adding the `android:descendantFocusability="blocksDescendants"` property to the viewer container, to match the main tachiyomi repo which doesn't have this issue.