### PR TITLE
When saving dual-page, check folderPerManga pref

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -749,11 +749,14 @@ class ReaderPresenter(
             notifier.onClear()
 
             // Pictures directory.
-            val destDir = File(
-                Environment.getExternalStorageDirectory().absolutePath +
+            val baseDir = Environment.getExternalStorageDirectory().absolutePath +
                     File.separator + Environment.DIRECTORY_PICTURES +
                     File.separator + context.getString(R.string.app_name)
-            )
+            val destDir = if (preferences.folderPerManga()) {
+                File(baseDir + File.separator + DiskUtil.buildValidFilename(manga.title))
+            } else {
+                File(baseDir)
+            }
 
             try {
                 val file = saveImages(firstPage, secondPage, isLTR, bg, destDir, manga)


### PR DESCRIPTION
Fixed this a while ago for Sy and while I intended to PR to j2k, I kinda forgot xd

Refer issue from sy repo - https://github.com/jobobby04/TachiyomiSY/issues/542
Title: "Saving combined image in Dual page reader doesnt follow enabling `Save pages into separate folder` setting" 

Also kinda relevant: ghostbear subsequently updated the save/share logic to final remove the deprecated environment calls used there
Final changed `SaveImage` response: https://github.com/tachiyomiorg/tachiyomi/blob/master/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt#L586
Relevant PRs: https://github.com/tachiyomiorg/tachiyomi/pull/6787, https://github.com/tachiyomiorg/tachiyomi/pull/6800, https://github.com/tachiyomiorg/tachiyomi/pull/6827