### PR TITLE
Auto split long images to improve performance of readers

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -651,6 +651,11 @@ class Downloader(
      * Returns true if all the queued downloads are in DOWNLOADED or ERROR state.
      */
     private fun areAllDownloadsFinished(): Boolean {
+        if (queue.none { it.status <= Download.State.DOWNLOADING }) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                context.dataDir.let { File("$it/app_webview/").deleteRecursively() }
+            }
+        }
         return queue.none { it.status <= Download.State.DOWNLOADING }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -310,6 +310,8 @@ class PreferencesHelper(val context: Context) {
 
     fun saveChaptersAsCBZ() = flowPrefs.getBoolean("save_chapter_as_cbz", true)
 
+    fun splitLongImages() = flowPrefs.getBoolean("split_long_images", true)
+
     fun downloadNewCategories() = flowPrefs.getStringSet(Keys.downloadNewCategories, emptySet())
     fun downloadNewCategoriesExclude() = flowPrefs.getStringSet(Keys.downloadNewCategoriesExclude, emptySet())
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -51,6 +51,11 @@ class SettingsDownloadController : SettingsController() {
             bindTo(preferences.saveChaptersAsCBZ())
             titleRes = R.string.save_chapters_as_cbz
         }
+        switchPreference {
+            bindTo(preferences.splitLongImages())
+            titleRes = R.string.split_long_images
+            summaryRes = R.string.split_long_images_summary
+        }
         preferenceCategory {
             titleRes = R.string.remove_after_read
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -942,6 +942,8 @@
     <string name="always_delete">Always delete</string>
     <string name="automatic_removal">Automatic removal</string>
     <string name="save_chapters_as_cbz">Save as CBZ archive</string>
+    <string name="split_long_images">Auto split long images</string>
+    <string name="split_long_images_summary">Enabling this will improve reader performance by splitting long images. It is recommended to keep this turned on.</string>
 
     <!-- Time -->
     <string name="manual">Manual</string>


### PR DESCRIPTION
Added a feature to optimize downloaded chapters reading performance and stability 
Fixes: https://github.com/tachiyomiorg/tachiyomi/issues/6973  https://github.com/tachiyomiorg/tachiyomi/issues/1908 https://github.com/Jays2Kings/tachiyomiJ2K/issues/1211
