### PR TITLE
Auto split tall downloaded images

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.data.download
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Build
 import android.os.Environment
 import android.provider.Settings
@@ -40,6 +42,8 @@ import timber.log.Timber
 import uy.kohesive.injekt.injectLazy
 import java.io.BufferedOutputStream
 import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -365,7 +369,12 @@ class Downloader(
             // Concurrently do 5 pages at a time
             .flatMap({ page -> getOrDownloadImage(page, download, tmpDir) }, 5)
             // Do when page is downloaded.
-            .doOnNext { notifier.onProgressChange(download) }
+            .doOnNext { page ->
+                if (preferences.splitLongImages().get()) {
+                    splitLongImage(page, tmpDir)
+                }
+                notifier.onProgressChange(download)
+            }
             .toList()
             .map { download }
             // Do after download completes
@@ -403,7 +412,7 @@ class Downloader(
         tmpFile?.delete()
 
         // Try to find the image file.
-        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.") }
+        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.") || it.name!!.contains("${filename}__001") }
 
         // If the image is already downloaded, do nothing. Otherwise download from network
         val pageObservable = when {
@@ -522,7 +531,7 @@ class Downloader(
         dirname: String
     ) {
         // Ensure that the chapter folder has all the images.
-        val downloadedImages = tmpDir.listFiles().orEmpty().filterNot { it.name!!.endsWith(".tmp") }
+        val downloadedImages = tmpDir.listFiles().orEmpty().filterNot { it.name!!.endsWith(".tmp") || (it.name!!.contains("__") && !it.name!!.contains("__001.jpg")) }
 
         download.status = if (downloadedImages.size == download.pages!!.size) {
             Download.State.DOWNLOADED
@@ -559,6 +568,63 @@ class Downloader(
             }
             cache.addChapter(dirname, download.manga)
             DiskUtil.createNoMediaFile(tmpDir, context)
+        }
+    }
+
+    /**
+     * Splits Long images to improve performance of reader
+     */
+    private fun splitLongImage(page: Page, tmpDir: UniFile) {
+        val filename = String.format("%03d", page.number)
+        val imageFile = tmpDir.listFiles()!!.find { it.name!!.startsWith("$filename.") } ?: return
+        // Implementation of Auto Split long images upon download.
+        // Checking the image dimensions without loading it in the memory.
+        val options = BitmapFactory.Options()
+        options.inJustDecodeBounds = true
+        BitmapFactory.decodeFile(imageFile.filePath, options)
+        val width = options.outWidth
+        val height = options.outHeight
+        val ratio = height / width
+
+        // Check ratio and if this is a tall image then split
+        if (ratio > 3) {
+            // I noticed 1000px runs smoother than screen height below, will keep it  until someone can discover a more optimal number
+            val splitsCount: Int = height / context.resources.displayMetrics.heightPixels + 1
+            val splitHeight = height / splitsCount
+
+            // Getting the scaled bitmap of the source image
+            val bitmap = BitmapFactory.decodeFile(imageFile.filePath)
+            val scaledBitmap: Bitmap =
+                Bitmap.createScaledBitmap(bitmap, bitmap.width, bitmap.height, true)
+
+            // xCord and yCord are the pixel positions of the image splits
+            var yCord = 0
+            val xCord = 0
+            try {
+                for (i in 0 until splitsCount) {
+                    val splitPath = imageFile.filePath!!.substringBeforeLast(".") + "__${"%03d".format(i + 1)}.jpg"
+                    // Compress the bitmap and save in jpg format
+                    val stream: OutputStream = FileOutputStream(splitPath)
+                    Bitmap.createBitmap(
+                        scaledBitmap,
+                        xCord,
+                        yCord,
+                        width,
+                        splitHeight,
+                    ).compress(Bitmap.CompressFormat.JPEG, 100, stream)
+                    stream.flush()
+                    stream.close()
+                    yCord += splitHeight
+                }
+                imageFile.delete()
+            } catch (e: Exception) {
+                // Image splits were not successfully saved so delete them and keep the original image
+                for (i in 0 until splitsCount) {
+                    val splitPath = imageFile.filePath!!.substringBeforeLast(".") + "__${"%03d".format(i + 1)}.jpg"
+                    File(splitPath).delete()
+                }
+                throw e
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -237,6 +237,8 @@ class PreferencesHelper(val context: Context) {
 
     fun downloadOnlyOverWifi() = prefs.getBoolean(Keys.downloadOnlyOverWifi, true)
 
+    fun splitLongImages() = flowPrefs.getBoolean("split_long_images", true)
+
     fun folderPerManga() = prefs.getBoolean(Keys.folderPerManga, false)
 
     fun librarySearchSuggestion() = flowPrefs.getString(Keys.librarySearchSuggestion, "")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -51,6 +51,12 @@ class SettingsDownloadController : SettingsController() {
             bindTo(preferences.saveChaptersAsCBZ())
             titleRes = R.string.save_chapters_as_cbz
         }
+        switchPreference {
+            bindTo(preferences.splitLongImages())
+            titleRes = R.string.split_long_images
+            summaryRes = R.string.split_long_images_summary
+        }
+
         preferenceCategory {
             titleRes = R.string.remove_after_read
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -947,6 +947,8 @@
     <string name="always_delete">Always delete</string>
     <string name="automatic_removal">Automatic removal</string>
     <string name="save_chapters_as_cbz">Save as CBZ archive</string>
+    <string name="split_long_images">Auto split long images</string>
+    <string name="split_long_images_summary">Enabling this will improve reader performance by splitting long images. It is recommended to keep this turned on.</string>
 
     <!-- Time -->
     <string name="manual">Manual</string>


### PR DESCRIPTION
Hi jay, I noticed last merged feature in J2K https://github.com/Jays2Kings/tachiyomiJ2K/pull/1174 will work so great with this PR which currently planned to be merged later in main. Since the two features together will both work to fix the reader loading issue of loading long-strip images.

I wanted to open this PR here again specifically for that. Me and others in the original PR https://github.com/tachiyomiorg/tachiyomi/pull/7029 have done many tests during last few days and the code is very robust and working great.

### Here is how it looks in the settings:
![image](https://user-images.githubusercontent.com/39028181/166162531-02fefb76-cf19-4f19-84da-0e7bfaa38ad1.png)
