### PR TITLE
Fixed Restore Chapter Method

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
@@ -353,7 +353,7 @@ class FullBackupManager(context: Context) : AbstractBackupManager(context) {
             val dbChapter = dbChapters.find { it.url == chapter.url }
             if (dbChapter != null) {
                 chapter.id = dbChapter.id
-                chapter.copyFrom(dbChapter)
+                chapter.copyFrom(dbChapter, true)
                 if (dbChapter.read && !chapter.read) {
                     chapter.read = dbChapter.read
                     chapter.last_page_read = dbChapter.last_page_read

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
@@ -353,7 +353,7 @@ class FullBackupManager(context: Context) : AbstractBackupManager(context) {
             val dbChapter = dbChapters.find { it.url == chapter.url }
             if (dbChapter != null) {
                 chapter.id = dbChapter.id
-                chapter.copyFrom(dbChapter, true)
+                chapter.copyFrom(dbChapter, false)
                 if (dbChapter.read && !chapter.read) {
                     chapter.read = dbChapter.read
                     chapter.last_page_read = dbChapter.last_page_read

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/full/FullBackupManager.kt
@@ -353,7 +353,7 @@ class FullBackupManager(context: Context) : AbstractBackupManager(context) {
             val dbChapter = dbChapters.find { it.url == chapter.url }
             if (dbChapter != null) {
                 chapter.id = dbChapter.id
-                chapter.copyFrom(dbChapter, false)
+                chapter.copyFrom(dbChapter as SChapter)
                 if (dbChapter.read && !chapter.read) {
                     chapter.read = dbChapter.read
                     chapter.last_page_read = dbChapter.last_page_read

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -39,17 +39,17 @@ interface Chapter : SChapter, Serializable {
         }
     }
 
-    fun copyFrom(other: Chapter, isRestore: Boolean = false) {
-        id = other.id
-        manga_id = other.manga_id
-        if (!isRestore) {
+    fun copyFrom(other: Chapter, overwrite: Boolean = true) {
+        if (overwrite) {
+            id = other.id
+            manga_id = other.manga_id
             read = other.read
             bookmark = other.bookmark
             last_page_read = other.last_page_read
+            pages_left = other.pages_left
+            date_fetch = other.date_fetch
+            source_order = other.source_order
         }
-        pages_left = other.pages_left
-        date_fetch = other.date_fetch
-        source_order = other.source_order
         copyFrom(other as SChapter)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -39,12 +39,14 @@ interface Chapter : SChapter, Serializable {
         }
     }
 
-    fun copyFrom(other: Chapter) {
+    fun copyFrom(other: Chapter, isRestore: Boolean = false) {
         id = other.id
         manga_id = other.manga_id
-        read = other.read
-        bookmark = other.bookmark
-        last_page_read = other.last_page_read
+        if (!isRestore) {
+            read = other.read
+            bookmark = other.bookmark
+            last_page_read = other.last_page_read
+        }
         pages_left = other.pages_left
         date_fetch = other.date_fetch
         source_order = other.source_order

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -39,17 +39,15 @@ interface Chapter : SChapter, Serializable {
         }
     }
 
-    fun copyFrom(other: Chapter, overwrite: Boolean = true) {
-        if (overwrite) {
-            id = other.id
-            manga_id = other.manga_id
-            read = other.read
-            bookmark = other.bookmark
-            last_page_read = other.last_page_read
-            pages_left = other.pages_left
-            date_fetch = other.date_fetch
-            source_order = other.source_order
-        }
+    fun copyFrom(other: Chapter) {
+        id = other.id
+        manga_id = other.manga_id
+        read = other.read
+        bookmark = other.bookmark
+        last_page_read = other.last_page_read
+        pages_left = other.pages_left
+        date_fetch = other.date_fetch
+        source_order = other.source_order
         copyFrom(other as SChapter)
     }
 }


### PR DESCRIPTION
Fixed: [[Bug] Restore backup - chapter read status #1256](https://github.com/Jays2Kings/tachiyomiJ2K/issues/1256)

Upstream has a different version of `copyFrom` that doesn't overwrite. So I tried to mimic the behavior without impacting anything else by adding an optional flag.

I have tested this with multiple test cases and it worked totally normal as expected.