### PR TITLE
Fix order of the extension label in ExtensionHolder

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/ExtensionHolder.kt
@@ -22,7 +22,6 @@ import eu.kanade.tachiyomi.util.system.LocaleHelper
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import eu.kanade.tachiyomi.util.system.timeSpanFromNow
 import eu.kanade.tachiyomi.util.view.resetStrokeColor
-import uy.kohesive.injekt.api.get
 import java.util.Locale
 
 class ExtensionHolder(view: View, val adapter: ExtensionAdapter) :
@@ -90,8 +89,8 @@ class ExtensionHolder(view: View, val adapter: ExtensionAdapter) :
         binding.lang.text = LocaleHelper.getDisplayName(extension.lang)
         binding.warning.text = when {
             extension is Extension.Untrusted -> itemView.context.getString(R.string.untrusted)
-            extension is Extension.Installed && extension.isObsolete -> itemView.context.getString(R.string.obsolete)
             extension is Extension.Installed && extension.isUnofficial -> itemView.context.getString(R.string.unofficial)
+            extension is Extension.Installed && extension.isObsolete -> itemView.context.getString(R.string.obsolete)
             extension.isNsfw -> itemView.context.getString(R.string.nsfw_short)
             else -> ""
         }.uppercase(Locale.ROOT)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsHeaderAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsHeaderAdapter.kt
@@ -59,14 +59,12 @@ class ExtensionDetailsHeaderAdapter(private val presenter: ExtensionDetailsPrese
                 it.context.startActivity(intent)
             }
 
-            if (extension.isObsolete) {
-                binding.extensionWarningBanner.isVisible = true
-                binding.extensionWarningBanner.setText(R.string.obsolete_extension_message)
-            }
-
             if (extension.isUnofficial) {
                 binding.extensionWarningBanner.isVisible = true
                 binding.extensionWarningBanner.setText(R.string.unofficial_extension_message)
+            } else if (extension.isObsolete) {
+                binding.extensionWarningBanner.isVisible = true
+                binding.extensionWarningBanner.setText(R.string.obsolete_extension_message)
             }
         }
     }


### PR DESCRIPTION
The `UNOFFICIAL` label is never displayed because the extension is also marked as obsolete
The only necessary change is in `ExtensionHolder`