### PR TITLE
Improves library badges when small font

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -167,10 +167,10 @@ class EditMangaDialog : DialogController {
         }
         binding.mangaStatus.setSelection(manga.status.coerceIn(SManga.UNKNOWN, SManga.ON_HIATUS))
         val oldType = manga.seriesType()
+        binding.seriesType.setSelection(oldType - 1)
         binding.seriesType.onItemSelectedListener = {
             binding.resetsReadingMode.isVisible = it + 1 != oldType
         }
-        binding.seriesType.setSelection(oldType - 1)
         binding.mangaGenresTags.clearFocus()
         binding.coverLayout.setOnClickListener {
             infoController.changeCover()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/EditMangaDialog.kt
@@ -49,7 +49,7 @@ class EditMangaDialog : DialogController {
     private var willResetCover = false
 
     lateinit var binding: EditMangaDialogBinding
-    val langauges = mutableListOf<String>()
+    private val languages = mutableListOf<String>()
 
     private val infoController
         get() = targetController as MangaDetailsController
@@ -107,8 +107,8 @@ class EditMangaDialog : DialogController {
             val extensionManager: ExtensionManager by injectLazy()
             val activeLangs = preferences.enabledLanguages().get()
 
-            langauges.add("")
-            langauges.addAll(
+            languages.add("")
+            languages.addAll(
                 extensionManager.availableExtensions.groupBy { it.lang }.keys
                     .sortedWith(
                         compareBy(
@@ -119,12 +119,12 @@ class EditMangaDialog : DialogController {
                     .filter { it != "all" },
             )
             binding.mangaLang.setEntries(
-                langauges.map {
+                languages.map {
                     LocaleHelper.getSourceDisplayName(it, binding.root.context)
                 },
             )
             binding.mangaLang.setSelection(
-                langauges.indexOf(LocalSource.getMangaLang(manga, binding.root.context))
+                languages.indexOf(LocalSource.getMangaLang(manga, binding.root.context))
                     .takeIf { it > -1 } ?: 0,
             )
         } else {
@@ -167,10 +167,10 @@ class EditMangaDialog : DialogController {
         }
         binding.mangaStatus.setSelection(manga.status.coerceIn(SManga.UNKNOWN, SManga.ON_HIATUS))
         val oldType = manga.seriesType()
-        binding.seriesType.setSelection(oldType - 1)
         binding.seriesType.onItemSelectedListener = {
             binding.resetsReadingMode.isVisible = it + 1 != oldType
         }
+        binding.seriesType.setSelection(oldType - 1)
         binding.mangaGenresTags.clearFocus()
         binding.coverLayout.setOnClickListener {
             infoController.changeCover()
@@ -331,7 +331,7 @@ class EditMangaDialog : DialogController {
             binding.mangaGenresTags.tags,
             binding.mangaStatus.selectedPosition,
             if (binding.resetsReadingMode.isVisible) binding.seriesType.selectedPosition + 1 else null,
-            langauges.getOrNull(binding.mangaLang.selectedPosition),
+            languages.getOrNull(binding.mangaLang.selectedPosition),
             willResetCover,
         )
     }

--- a/app/src/main/res/layout/unread_download_badge.xml
+++ b/app/src/main/res/layout/unread_download_badge.xml
@@ -8,6 +8,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     app:cardElevation="0dp"
+    app:cardBackgroundColor="@android:color/transparent"
     android:layout_marginStart="2dp"
     android:layout_marginTop="5dp"
     android:visibility="gone"
@@ -51,15 +52,15 @@
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/bottom_text_barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:barrierDirection="bottom"
             app:constraint_referenced_ids="download_text,unread_text" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/top_text_barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
             app:barrierDirection="top"
             app:constraint_referenced_ids="download_text,unread_text" />
 
@@ -67,7 +68,7 @@
             android:id="@+id/download_text"
             style="?textAppearanceCaption"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:background="?colorTertiary"
             android:gravity="center"
             android:maxLines="1"
@@ -76,6 +77,7 @@
             android:textColor="@color/download_badge_text"
             android:textSize="13sp"
             android:visibility="gone"
+            app:layout_constraintHeight_min="wrap"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/lang_image"
             app:layout_constraintTop_toTopOf="parent"
@@ -99,7 +101,7 @@
             android:id="@+id/unread_text"
             style="?textAppearanceCaption"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:background="?attr/colorSecondary"
             android:gravity="center"
             android:maxLines="1"
@@ -108,10 +110,11 @@
             android:textColor="?colorOnSecondary"
             android:textSize="13sp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@+id/download_text"
+            app:layout_constraintHeight_min="wrap"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/download_text"
-            app:layout_constraintTop_toTopOf="@+id/download_text"
+            app:layout_constraintTop_toTopOf="parent"
             tools:text="20"
             tools:visibility="visible"
             tools:paddingStart="2dp"/>


### PR DESCRIPTION
Some minor fixes:
- In the `EditMangaDialog`, the `onItemSelectedListener` should be set before the `setSelection` otherwise the `originalSelection` is reset to blank and is not visible when we first open the series type (if the original was not already selected)
- For the library badges, I use a small font and the language flag's height was a bit bigger than the unread/download badges'. With these changes it should always have the same height