### PR TITLE
Fix manga not initialized in getSource

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderPresenter.kt
@@ -640,11 +640,11 @@ class ReaderPresenter(
     }
 
     fun getChapterUrl(): String? {
+        val manga = manga ?: return null
         val source = getSource() ?: return null
         val chapter = getCurrentChapter()?.chapter ?: return null
-        val chapterUrl = chapter.url.getUrlWithoutDomain()
 
-        val manga = manga ?: return null
+        val chapterUrl = chapter.url.getUrlWithoutDomain()
         val mangaUrl = source.mangaDetailsRequest(manga).url.toString()
         return if (chapterUrl.isBlank()) {
             mangaUrl
@@ -678,7 +678,7 @@ class ReaderPresenter(
         }
     }
 
-    fun getSource() = sourceManager.getOrStub(manga!!.source) as? HttpSource
+    fun getSource() = manga?.source?.let { sourceManager.getOrStub(it) } as? HttpSource
 
     /**
      * Returns the viewer position used by this manga or the default one.


### PR DESCRIPTION
Closes #1293 

It should fix this crash. Not sure why `manga` is null though
Only either the modification of `getSource()` or putting the manga initialization earlier is necessary but well I did both, better be safe than sorry