### PR TITLE
Hold to edit manga categories instead of popup

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -1443,14 +1443,10 @@ class MangaDetailsController :
 
     override fun favoriteManga(longPress: Boolean) {
         if (needsToBeUnlocked()) return
-        val manga = presenter.manga
-        val categories = presenter.getCategories()
-        if (!manga.favorite) {
-            toggleMangaFavorite()
+        if (longPress) {
+            showCategoriesSheet()
         } else {
-            val favButton = getHeader()?.binding?.favoriteButton ?: return
-            val popup = makeFavPopup(favButton, categories)
-            popup?.show()
+            toggleMangaFavorite()
         }
     }
 
@@ -1478,15 +1474,19 @@ class MangaDetailsController :
         // Set a listener so we are notified if a menu item is clicked
         popup.setOnMenuItemClickListener { menuItem ->
             if (menuItem.itemId == 0) {
-                presenter.manga.moveCategories(presenter.db, activity!!) {
-                    updateHeader()
-                }
+                showCategoriesSheet()
             } else {
                 toggleMangaFavorite()
             }
             true
         }
         return popup
+    }
+
+    private fun showCategoriesSheet() {
+        presenter.manga.moveCategories(presenter.db, activity!!) {
+            updateHeader()
+        }
     }
 
     private fun toggleMangaFavorite() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
@@ -128,6 +128,10 @@ class MangaHeaderHolder(
             favoriteButton.setOnClickListener {
                 adapter.delegate.favoriteManga(false)
             }
+            favoriteButton.setOnLongClickListener {
+                adapter.delegate.favoriteManga(true)
+                true
+            }
             title.setOnClickListener { view ->
                 title.text?.toString()?.toNormalized()?.let {
                     adapter.delegate.showFloatingActionMode(view as TextView, it)


### PR DESCRIPTION
Hold on Favorite manga button to edit categories instead of clicking and then showing a popup.
Will reduce 2 clicks for removing manga from library and when editing categories
Closes https://github.com/Jays2Kings/tachiyomiJ2K/issues/1133