### PR TITLE
Allow user to toggle showing all categories when searching

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -392,6 +392,8 @@ class PreferencesHelper(val context: Context) {
 
     fun showAllCategories() = flowPrefs.getBoolean("show_all_categories", true)
 
+    fun showAllCategoriesWhenSearching() = flowPrefs.getBoolean("show_all_categories_when_searching", true)
+
     fun hopperGravity() = flowPrefs.getInt("hopper_gravity", 1)
 
     fun filterOrder() = flowPrefs.getString("filter_order", FilterBottomSheet.Filters.DEFAULT_ORDER)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -1340,7 +1340,7 @@ class LibraryController(
     }
 
     fun search(query: String?): Boolean {
-        if (!query.isNullOrBlank() && this.query.isBlank() && !presenter.showAllCategories) {
+        if (!query.isNullOrBlank() && this.query.isBlank() && !presenter.showAllCategories && presenter.showAllCategoriesWhenSearching) {
             presenter.forceShowAllCategories = true
             presenter.getLibrary()
         } else if (query.isNullOrBlank() && this.query.isNotBlank() && presenter.forceShowAllCategories) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -95,6 +95,7 @@ class LibraryPresenter(
     var forceShowAllCategories = false
     val showAllCategories
         get() = forceShowAllCategories || preferences.showAllCategories().get()
+    val showAllCategoriesWhenSearching get() = preferences.showAllCategoriesWhenSearching().get()
 
     private val libraryIsGrouped
         get() = groupType != UNGROUPED

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/display/LibraryCategoryView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/display/LibraryCategoryView.kt
@@ -19,6 +19,11 @@ class LibraryCategoryView @JvmOverloads constructor(context: Context, attrs: Att
             showAll.bindToPreference(preferences.showAllCategories()) {
                 controller?.presenter?.getLibrary()
                 binding.categoryShow.isEnabled = it
+                showAllWhenSearching.isEnabled = !it
+            }
+            showAllWhenSearching.isEnabled = !showAll.isChecked
+            showAllWhenSearching.bindToPreference(preferences.showAllCategoriesWhenSearching()) {
+                controller?.showMiniBar()
             }
             categoryShow.isEnabled = showAll.isChecked
             categoryShow.bindToPreference(preferences.showCategoryInTitle()) {

--- a/app/src/main/res/layout/library_category_layout.xml
+++ b/app/src/main/res/layout/library_category_layout.xml
@@ -28,6 +28,14 @@
             android:text="@string/show_all_categories" />
 
         <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/show_all_when_searching"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
+            android:text="@string/show_all_categories_when_searching" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/dynamic_to_bottom"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="no_matches_for_filters">No matches found for your current filters</string>
     <string name="getting_started_guide">Getting started guide</string>
     <string name="show_all_categories">Show all categories</string>
+    <string name="show_all_categories_when_searching">Show all categories when searching</string>
     <string name="move_dynamic_to_bottom">Move collapsed dynamic categories to bottom</string>
     <string name="show_number_of_items">Show number of items</string>
     <string name="when_grouping_by_sources_tags">When grouping library by sources, status, etc.</string>


### PR DESCRIPTION
This PR makes it possible for a user to specify whether or not library search should show all categories when "Show All Categories" is off (see #1312 which introduced this behavior)

&nbsp;

<img width="360" alt="image" src="https://user-images.githubusercontent.com/83582211/178919906-6cbabb0d-fb01-4838-a113-cd4e55284935.png" style="max-width: 100%;">
