### PR TITLE
Fix language info extensions

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SourceHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/SourceHolder.kt
@@ -26,10 +26,7 @@ class SourceHolder(view: View, val adapter: SourceAdapter) :
         val source = item.source
 
         // Set source name
-        val sourceName =
-            if (adapter.isMultiLanguage) source.toString() else source.name.replaceFirstChar {
-                it.titlecase(Locale.getDefault())
-            } + " (${item.numberOfItems})"
+        val sourceName = source.name.replaceFirstChar { it.titlecase(Locale.getDefault()) } + " (${item.numberOfItems})"
         binding.title.text = sourceName
         binding.lang.text = when {
             item.isUninstalled -> itemView.context.getString(R.string.source_not_installed)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourceHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourceHolder.kt
@@ -30,10 +30,11 @@ class SourceHolder(view: View, val adapter: SourceAdapter) :
         // setCardEdges(item)
 
         val underPinnedSection = item.header?.code?.equals(SourcePresenter.PINNED_KEY) ?: false
+        val underLastUsedSection = item.header?.code?.equals(SourcePresenter.LAST_USED_KEY) ?: false
         val isPinned = item.isPinned ?: underPinnedSection
         // Set source name
         val sourceName =
-            if (adapter.isMultiLanguage && underPinnedSection) source.toString() else source.name
+            if (adapter.isMultiLanguage && (underPinnedSection || underLastUsedSection)) source.toString() else source.name
         binding.title.text = sourceName
 
         binding.sourcePin.apply {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/SourcePresenter.kt
@@ -109,7 +109,7 @@ class SourcePresenter(
             val pinnedCatalogues = preferences.pinnedCatalogues().get()
             val isPinned = source.id.toString() in pinnedCatalogues
             if (isPinned) null
-            else SourceItem(source, null, isPinned)
+            else SourceItem(source, LangItem(LAST_USED_KEY), isPinned)
         }
     }
 


### PR DESCRIPTION
I removed the `(lang)` after the source name for migration (in browse) page since you added the language below the source + fixed the number of items not visible when multi-language
I also added the `(lang)` for last used extension (same as pinned extensions)