### PR TITLE
Add toggle during search to show all categories

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/SearchModifierItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/SearchModifierItem.kt
@@ -19,7 +19,7 @@ import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
  * @property toggleShowAllCategories A function that toggles forceShowAllCategories in the LibraryPresenter
  *                                   Returns the new value of  forceShowAllCategories
  */
-class SearchGlobalItem(val toggleShowAllCategories: () -> Boolean) : AbstractFlexibleItem<SearchGlobalItem.Holder>() {
+class SearchModifierItem(val toggleShowAllCategories: () -> Boolean) : AbstractFlexibleItem<SearchModifierItem.Holder>() {
 
     var string = ""
     var allCategoriesToggleIsVisible = false
@@ -81,13 +81,13 @@ class SearchGlobalItem(val toggleShowAllCategories: () -> Boolean) : AbstractFle
             }
 
             binding.global.button.setOnClickListener {
-                val query = (adapter.getItem(flexibleAdapterPosition) as SearchGlobalItem).string
+                val query = (adapter.getItem(flexibleAdapterPosition) as SearchModifierItem).string
                 (adapter as? LibraryCategoryAdapter)?.libraryListener?.globalSearch(query)
             }
 
             allCategoriesToggleIsVisible = false
             binding.allCategories.button.setOnClickListener {
-                (adapter.getItem(flexibleAdapterPosition) as SearchGlobalItem).apply {
+                (adapter.getItem(flexibleAdapterPosition) as SearchModifierItem).apply {
                     isForceShowingAllCategories = toggleShowAllCategories()
                 }
             }

--- a/app/src/main/res/layout/search_modifier_item.xml
+++ b/app/src/main/res/layout/search_modifier_item.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <include
+        android:id="@+id/global"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        layout="@layout/material_text_button" />
+    <include
+        android:id="@+id/all_categories"
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        layout="@layout/material_text_button" />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -151,7 +151,8 @@
     <string name="reorder_filters">Reorder filters</string>
     <string name="_unread">%d unread</string>
     <string name="search_globally">Search \"%1$s\" globally</string>
-
+    <string name="search_all_categories">Search \"%1$s\" in all categories</string>
+    <string name="search_current_category">Search \"%1$s\" in current category</string>
     <string name="read_progress">Read progress</string>
     <string name="series_type">Series type</string>
     <string name="series">Series</string>


### PR DESCRIPTION
This PR reverts the behavior introduced by #1312, and adds a toggle for searching all categories/current category.

Supercedes #1340

The toggle is only visible when:
   * A search is active
   * A library is grouped by categories
   * `Show all categories` is disabled

<img width="360" alt="image" src="https://user-images.githubusercontent.com/83582211/184577461-854bb013-ac80-4f00-b58d-b94f38fb6e3b.png" style="max-width: 100%;">

<img width="360" alt="image" src="https://user-images.githubusercontent.com/83582211/184577502-b251b902-bde9-4d6f-9d49-e1fd8349db17.png" style="max-width: 100%;">




