### PR TITLE
Add toggle to searchbar  to force show all categories

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -393,6 +393,8 @@ class PreferencesHelper(val context: Context) {
 
     fun showAllCategories() = flowPrefs.getBoolean("show_all_categories", true)
 
+    fun showAllCategoriesWhenSearchingSingleCategory() = flowPrefs.getBoolean("show_all_categories_when_searching_single_category", false)
+
     fun hopperGravity() = flowPrefs.getInt("hopper_gravity", 1)
 
     fun filterOrder() = flowPrefs.getString("filter_order", FilterBottomSheet.Filters.DEFAULT_ORDER)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/MiniSearchView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/MiniSearchView.kt
@@ -66,4 +66,16 @@ class MiniSearchView @JvmOverloads constructor(context: Context, attrs: Attribut
         }
         requestLayout()
     }
+
+    fun addSearchModifierIcon(imageViewFactory: (Context) -> ImageView): ImageView? {
+        return findViewById<LinearLayout>(androidx.appcompat.R.id.search_plate)?.let { searchPlateView ->
+            val imageView = imageViewFactory(searchPlateView.context)
+            val clearButton = findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
+            imageView.layoutParams = clearButton?.layoutParams
+            searchPlateView.addView(imageView, 1)
+            return imageView
+        }
+    }
+
+    fun removeSearchModifierIcon(view: ImageView) = findViewById<LinearLayout>(androidx.appcompat.R.id.search_plate)?.removeView(view)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -19,8 +19,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.MotionEvent
 import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
 import android.view.ViewTreeObserver
@@ -36,6 +34,7 @@ import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.ime
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.isGone
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
@@ -1360,7 +1359,7 @@ class LibraryController(
             binding.libraryGridRecycler.recycler.scrollToPosition(0)
         }
         this.query = query ?: ""
-        showAllCategoriesView.visibility = if (!presenter.showAllCategories && presenter.groupType == BY_DEFAULT && this.query.isNotBlank()) VISIBLE else GONE
+        showAllCategoriesView.isGone = presenter.showAllCategories || presenter.groupType != BY_DEFAULT || this.query.isBlank()
         if (this.query.isNotBlank()) {
             searchItem.string = this.query
             if (adapter.scrollableHeaders.isEmpty()) { adapter.addScrollableHeader(searchItem) }
@@ -1811,7 +1810,7 @@ class LibraryController(
         showAllCategoriesView = (searchView as? MiniSearchView)?.addSearchModifierIcon { context ->
             ImageView(context).apply {
                 isSelected = presenter.forceShowAllCategories
-                visibility = GONE
+                isGone = true
                 setOnClickListener {
                     presenter.forceShowAllCategories = !presenter.forceShowAllCategories
                     presenter.getLibrary()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -1814,7 +1814,7 @@ class LibraryController(
         val searchView = activityBinding?.searchToolbar?.searchView
         activityBinding?.searchToolbar?.setQueryHint(resources?.getString(R.string.library_search_hint), query.isEmpty())
 
-        showAllCategoriesView = (searchView as? MiniSearchView)?.addSearchModifierIcon { context ->
+        showAllCategoriesView = showAllCategoriesView ?: (searchView as? MiniSearchView)?.addSearchModifierIcon { context ->
             ImageView(context).apply {
                 isSelected = presenter.forceShowAllCategories
                 isGone = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -246,7 +246,7 @@ class LibraryController(
     private var staggeredObserver: ViewTreeObserver.OnGlobalLayoutListener? = null
 
     // Dynamically injected into the search bar, controls category visibility during search
-    private lateinit var showAllCategoriesView: ImageView
+    private var showAllCategoriesView: ImageView? = null
     override fun getTitle(): String? {
         setSubtitle()
         return view?.context?.getString(R.string.library)
@@ -1059,7 +1059,9 @@ class LibraryController(
         mAdapter = null
         saveStaggeredState()
 
-        (activityBinding?.searchToolbar?.searchView as? MiniSearchView)?.removeSearchModifierIcon(showAllCategoriesView)
+        showAllCategoriesView?.let {
+            (activityBinding?.searchToolbar?.searchView as? MiniSearchView)?.removeSearchModifierIcon(it)
+        }
         super.onDestroyView(view)
     }
 
@@ -1352,14 +1354,14 @@ class LibraryController(
         if (query.isNullOrBlank() && this.query.isNotBlank() && presenter.forceShowAllCategories) {
             presenter.forceShowAllCategories = false
             presenter.getLibrary()
-            showAllCategoriesView.isSelected = presenter.forceShowAllCategories
+            showAllCategoriesView?.isSelected = presenter.forceShowAllCategories
         }
 
         if (query != this.query && !query.isNullOrBlank()) {
             binding.libraryGridRecycler.recycler.scrollToPosition(0)
         }
         this.query = query ?: ""
-        showAllCategoriesView.isGone = presenter.showAllCategories || presenter.groupType != BY_DEFAULT || this.query.isBlank()
+        showAllCategoriesView?.isGone = presenter.showAllCategories || presenter.groupType != BY_DEFAULT || this.query.isBlank()
         if (this.query.isNotBlank()) {
             searchItem.string = this.query
             if (adapter.scrollableHeaders.isEmpty()) { adapter.addScrollableHeader(searchItem) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -104,6 +104,7 @@ import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.rootWindowInsetsCompat
 import eu.kanade.tachiyomi.util.view.activityBinding
 import eu.kanade.tachiyomi.util.view.collapse
+import eu.kanade.tachiyomi.util.view.compatToolTipText
 import eu.kanade.tachiyomi.util.view.expand
 import eu.kanade.tachiyomi.util.view.fullAppBarHeight
 import eu.kanade.tachiyomi.util.view.getItemView
@@ -1818,9 +1819,7 @@ class LibraryController(
                 }
                 setImageResource(R.drawable.ic_show_all_categories_24dp)
                 imageTintList = ColorStateList.valueOf(context.getResourceColor(R.attr.actionBarTintColor))
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    tooltipText = resources?.getText(R.string.show_all_categories)
-                }
+                compatToolTipText = resources?.getText(R.string.show_all_categories)
             }
         }!!
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -1351,17 +1351,22 @@ class LibraryController(
     }
 
     fun search(query: String?): Boolean {
-        if (query.isNullOrBlank() && this.query.isNotBlank() && presenter.forceShowAllCategories) {
+        val isShowAllCategoriesSet = preferences.showAllCategories().get()
+        if (!query.isNullOrBlank() && this.query.isBlank() && !isShowAllCategoriesSet) {
+            presenter.forceShowAllCategories = preferences.showAllCategoriesWhenSearchingSingleCategory().get()
+            presenter.getLibrary()
+        } else if (query.isNullOrBlank() && this.query.isNotBlank() && !isShowAllCategoriesSet) {
+            preferences.showAllCategoriesWhenSearchingSingleCategory().set(presenter.forceShowAllCategories)
             presenter.forceShowAllCategories = false
             presenter.getLibrary()
-            showAllCategoriesView?.isSelected = presenter.forceShowAllCategories
         }
 
         if (query != this.query && !query.isNullOrBlank()) {
             binding.libraryGridRecycler.recycler.scrollToPosition(0)
         }
         this.query = query ?: ""
-        showAllCategoriesView?.isGone = presenter.showAllCategories || presenter.groupType != BY_DEFAULT || this.query.isBlank()
+        showAllCategoriesView?.isGone = isShowAllCategoriesSet || presenter.groupType != BY_DEFAULT || this.query.isBlank()
+        showAllCategoriesView?.isSelected = presenter.forceShowAllCategories
         if (this.query.isNotBlank()) {
             searchItem.string = this.query
             if (adapter.scrollableHeaders.isEmpty()) { adapter.addScrollableHeader(searchItem) }

--- a/app/src/main/res/drawable/ic_show_all_categories_24dp.xml
+++ b/app/src/main/res/drawable/ic_show_all_categories_24dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:state_selected="false" android:drawable="@drawable/ic_unfold_more_horizontal_24dp"/>
+    <item android:state_selected="true" android:drawable="@drawable/ic_unfold_less_horizontal_24dp"/>
+</selector>

--- a/app/src/main/res/drawable/ic_unfold_less_horizontal_24dp.xml
+++ b/app/src/main/res/drawable/ic_unfold_less_horizontal_24dp.xml
@@ -1,0 +1,8 @@
+<!-- drawable/unfold_less_horizontal.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M16.59,5.41L15.17,4L12,7.17L8.83,4L7.41,5.41L12,10M7.41,18.59L8.83,20L12,16.83L15.17,20L16.58,18.59L12,14L7.41,18.59Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_unfold_more_horizontal_24dp.xml
+++ b/app/src/main/res/drawable/ic_unfold_more_horizontal_24dp.xml
@@ -1,0 +1,8 @@
+<!-- drawable/unfold_more_horizontal.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#000" android:pathData="M12,18.17L8.83,15L7.42,16.41L12,21L16.59,16.41L15.17,15M12,5.83L15.17,9L16.58,7.59L12,3L7.41,7.59L8.83,9L12,5.83Z" />
+</vector>


### PR DESCRIPTION
This PR reverts the behavior introduced by #1312, and adds a toggle to show all categories during library search.

Supercedes #1375, which itself superceded #1340

The toggle is only visible when:
   * A search is active
   * A library is grouped by categories
   * `Show all categories` is disabled

<img width="240" alt="image" src="https://user-images.githubusercontent.com/83582211/185856626-2246ac54-1781-4f42-a724-3346ea28461a.png" style="max-width: 100%;">
<img width="240" alt="image" src="https://user-images.githubusercontent.com/83582211/185856736-18f52e65-e48f-43c6-bded-ec7109be0b2b.png" style="max-width: 100%;">


Tooltip on Long Press: 


<img width="240" alt="image" src="https://user-images.githubusercontent.com/83582211/185856798-6b7ba311-5f10-447c-bf64-fcf5bce2224a.png" style="max-width: 100%;">









