### PR TITLE
Change read duration total to include all history

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/HistoryQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/HistoryQueries.kt
@@ -128,6 +128,18 @@ interface HistoryQueries : DbProvider {
         )
         .prepare()
 
+    fun getTotalReadDuration(): Long {
+        val cursor = db.lowLevel()
+            .rawQuery(
+                RawQuery.builder()
+                    .query("SELECT SUM(${HistoryTable.COL_TIME_READ}) FROM ${HistoryTable.TABLE}")
+                    .observesTables(HistoryTable.TABLE)
+                    .build(),
+            )
+        cursor.moveToFirst()
+        return cursor.getLong(0)
+    }
+
     fun getHistoryByChapterUrl(chapterUrl: String) = db.get()
         .`object`(History::class.java)
         .withQuery(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/StatsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/StatsController.kt
@@ -24,6 +24,7 @@ import eu.kanade.tachiyomi.util.isLocal
 import eu.kanade.tachiyomi.util.mapStatus
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import eu.kanade.tachiyomi.util.system.roundToTwoDecimal
+import eu.kanade.tachiyomi.util.view.compatToolTipText
 import eu.kanade.tachiyomi.util.view.scrollViewWith
 import eu.kanade.tachiyomi.util.view.withFadeTransaction
 import timber.log.Timber
@@ -68,6 +69,7 @@ class StatsController : BaseController<StatsControllerBinding>() {
                 statsMangaMeanScoreText.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
                 activity?.getString(R.string.none)
             } else scoresList.average().roundToTwoDecimal().toString()
+            statsMangaMeanScoreLayout.compatToolTipText = activity?.getString(R.string.mean_score_info)
             statsTrackedMangaText.text = mangaTracks.count { it.second.isNotEmpty() }.toString()
             statsChaptersDownloadedText.text = mangaDistinct.sumOf { presenter.getDownloadCount(it) }.toString()
             statsTotalTagsText.text = mangaDistinct.flatMap { it.getTags() }.distinct().count().toString()
@@ -76,6 +78,7 @@ class StatsController : BaseController<StatsControllerBinding>() {
             statsSourcesText.text = presenter.getSources().count().toString()
             statsTrackersText.text = presenter.getLoggedTrackers().count().toString()
             statsReadDurationText.text = presenter.getReadDuration()
+            statsReadDurationLayout.compatToolTipText = activity?.getString(R.string.read_duration_info)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/StatsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/StatsPresenter.kt
@@ -78,9 +78,7 @@ class StatsPresenter(
     }
 
     fun getReadDuration(): String {
-        val chaptersTime = mangaDistinct.sumOf { manga ->
-            db.getHistoryByMangaId(manga.id!!).executeAsBlocking().sumOf { it.time_read }
-        }
+        val chaptersTime = db.getTotalReadDuration()
         return chaptersTime.getReadDuration(prefs.context.getString(R.string.none))
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsPresenter.kt
@@ -611,15 +611,15 @@ class StatsDetailsPresenter(
     enum class Stats(val resourceId: Int) {
         SERIES_TYPE(R.string.series_type),
         STATUS(R.string.status),
+        READ_DURATION(R.string.read_duration),
         SCORE(R.string.score),
-        LANGUAGE(R.string.language),
         LENGTH(R.string.length),
-        TRACKER(R.string.tracker),
+        LANGUAGE(R.string.language),
         SOURCE(R.string.source),
+        TRACKER(R.string.tracker),
         CATEGORY(R.string.category),
         TAG(R.string.tag),
         START_YEAR(R.string.start_year),
-        READ_DURATION(R.string.read_duration),
     }
 
     enum class StatsSort(val resourceId: Int) {

--- a/app/src/main/res/layout/list_chart_legend.xml
+++ b/app/src/main/res/layout/list_chart_legend.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
     android:layout_marginVertical="1dp"
     android:orientation="horizontal">
 
@@ -11,19 +11,34 @@
         android:id="@+id/legend_color_icon"
         android:layout_width="18dp"
         android:layout_height="18dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/filled_circle" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/legend_description_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginClose" />
+        android:layout_marginStart="@dimen/marginClose"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/legend_value_text"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toEndOf="@+id/legend_color_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_default="wrap"
+        tools:text="Publishing finished" />
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/legend_value_text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/marginNormal" />
+        android:layout_marginStart="@dimen/marginNormal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/legend_description_text"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="1205" />
 
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/stats_controller.xml
+++ b/app/src/main/res/layout/stats_controller.xml
@@ -18,30 +18,12 @@
         android:paddingTop="@dimen/marginSmall"
         android:paddingBottom="@dimen/marginSmall">
 
-        <LinearLayout
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/view_detail_layout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            style="@style/Widget.Tachiyomi.Button.OutlinedButton.Icon"
             android:layout_gravity="end"
-            android:layout_marginBottom="@dimen/marginNormal"
-            android:foreground="?selectableItemBackground"
-            android:gravity="center"
-            android:padding="@dimen/marginClose">
-
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="18dp"
-                android:layout_height="18dp"
-                android:layout_marginEnd="@dimen/marginClose"
-                app:srcCompat="@drawable/ic_brief"
-                app:tint="?attr/colorSecondary" />
-
-            <com.google.android.material.textview.MaterialTextView
-                style="?textAppearanceLabelLarge"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/view_detailed_statistics" />
-
-        </LinearLayout>
+            android:text="@string/view_detailed_statistics"
+            app:icon="@drawable/ic_brief" />
 
         <com.google.android.material.textview.MaterialTextView
             style="?textAppearanceLabelLarge"

--- a/app/src/main/res/layout/stats_controller.xml
+++ b/app/src/main/res/layout/stats_controller.xml
@@ -36,51 +36,104 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:baselineAligned="false"
-            android:gravity="center"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_total_manga_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_total_chapters_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_chapters_read_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
+            android:layout_marginBottom="20dp"
+            android:baselineAligned="false">
 
             <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose">
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_total_manga_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/titles_in_library" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_total_chapters_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/total_chapters" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_chapters_read_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/chapters_read" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/stats_manga_mean_score_layout"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/stats_manga_mean_score_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_gravity="center"
                     android:drawablePadding="3dp"
                     android:gravity="center"
                     android:textColor="?attr/colorSecondary"
@@ -88,239 +141,247 @@
                     app:drawableTint="?attr/colorSecondary"
                     tools:text="0" />
 
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/mean_score" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:baselineAligned="false">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_tracked_manga_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/tracked_titles" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_global_update_manga_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/titles_in_global_update" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_chapters_downloaded_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/downloaded_chapters" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/stats_read_duration_layout"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_read_duration_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/read_duration" />
+
             </LinearLayout>
         </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:baselineAligned="false"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/titles_in_library" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/total_chapters" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/chapters_read" />
-
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/mean_score" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:baselineAligned="false"
-            android:gravity="center"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_tracked_manga_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_global_update_manga_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_chapters_downloaded_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_read_duration_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:baselineAligned="false"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/tracked_titles" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/titles_in_global_update" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/downloaded_chapters" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/read_duration" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:baselineAligned="false"
-            android:gravity="center"
-            android:orientation="horizontal">
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_manga_local_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_total_tags_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_sources_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/stats_trackers_text"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:textColor="?attr/colorSecondary"
-                tools:text="0" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/marginPage"
-            android:baselineAligned="false"
-            android:orientation="horizontal">
+            android:baselineAligned="false">
 
-            <com.google.android.material.textview.MaterialTextView
+            <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
+                android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/local_titles" />
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/tags" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_manga_local_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
 
-            <com.google.android.material.textview.MaterialTextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/sources" />
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/local_titles" />
 
-            <com.google.android.material.textview.MaterialTextView
+            </LinearLayout>
+
+            <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/marginClose"
+                android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:gravity="center"
-                android:paddingHorizontal="@dimen/marginClose"
-                android:text="@string/trackers" />
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_total_tags_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/tags" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_sources_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/sources" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:paddingStart="@dimen/marginClose"
+                android:paddingEnd="@dimen/marginClose">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/stats_trackers_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:gravity="center"
+                    android:textColor="?attr/colorSecondary"
+                    tools:text="0" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom|center_horizontal"
+                    android:layout_marginTop="@dimen/marginClose"
+                    android:gravity="center"
+                    android:text="@string/trackers" />
+
+            </LinearLayout>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/stats_controller.xml
+++ b/app/src/main/res/layout/stats_controller.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/stats_scroll_view"
-    android:clipToPadding="false"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clipToPadding="false"
     android:fitsSystemWindows="true"
     tools:context="eu.kanade.tachiyomi.ui.more.stats.StatsController">
 
@@ -54,113 +54,51 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/marginPage"
-            android:baselineAligned="false">
+            android:baselineAligned="false"
+            android:gravity="center"
+            android:orientation="horizontal">
 
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_total_manga_text"
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_total_manga_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/titles_in_library" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_total_chapters_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_total_chapters_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/total_chapters" />
-
-            </LinearLayout>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_chapters_read_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
 
             <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_chapters_read_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/chapters_read" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
+                android:paddingHorizontal="@dimen/marginClose">
 
                 <com.google.android.material.textview.MaterialTextView
                     android:id="@+id/stats_manga_mean_score_text"
                     android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
                     android:drawablePadding="3dp"
                     android:gravity="center"
                     android:textColor="?attr/colorSecondary"
@@ -168,16 +106,194 @@
                     app:drawableTint="?attr/colorSecondary"
                     tools:text="0" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/mean_score" />
-
             </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/titles_in_library" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/total_chapters" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/chapters_read" />
+
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/mean_score" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:baselineAligned="false"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_tracked_manga_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_global_update_manga_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_chapters_downloaded_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_read_duration_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="20dp"
+            android:baselineAligned="false"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/tracked_titles" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/titles_in_global_update" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/downloaded_chapters" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/read_duration" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:baselineAligned="false"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_manga_local_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_total_tags_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_sources_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:paddingHorizontal="@dimen/marginClose"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/stats_trackers_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center"
+                android:textColor="?attr/colorSecondary"
+                tools:text="0" />
 
         </LinearLayout>
 
@@ -185,253 +301,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/marginPage"
-            android:baselineAligned="false">
+            android:baselineAligned="false"
+            android:orientation="horizontal">
 
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_tracked_manga_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="3"
-                    android:text="@string/tracked_titles" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_global_update_manga_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="3"
-                    android:text="@string/titles_in_global_update" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/local_titles" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_chapters_downloaded_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="3"
-                    android:text="@string/downloaded_chapters" />
-
-            </LinearLayout>
-
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/tags" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_manga_local_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="3"
-                    android:text="@string/local_titles" />
-
-            </LinearLayout>
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/marginPage"
-            android:baselineAligned="false">
-
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/sources" />
 
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_total_tags_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/tags" />
-
-            </LinearLayout>
-
-            <LinearLayout
+            <com.google.android.material.textview.MaterialTextView
                 android:layout_width="0dp"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/marginClose"
                 android:layout_weight="1"
                 android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_sources_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/sources" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_trackers_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/trackers" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:orientation="vertical"
-                android:paddingStart="@dimen/marginClose"
-                android:paddingEnd="@dimen/marginClose">
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/stats_read_duration_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="0dp"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:textColor="?attr/colorSecondary"
-                    tools:text="0" />
-
-                <com.google.android.material.textview.MaterialTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="bottom|center_horizontal"
-                    android:layout_marginTop="@dimen/marginClose"
-                    android:gravity="center"
-                    android:lines="2"
-                    android:text="@string/read_duration" />
-
-            </LinearLayout>
+                android:paddingHorizontal="@dimen/marginClose"
+                android:text="@string/trackers" />
 
         </LinearLayout>
 
@@ -442,7 +349,7 @@
             android:layout_marginBottom="@dimen/marginPage"
             android:orientation="vertical"
             android:visibility="gone"
-            tools:visibility="visible" >
+            tools:visibility="visible">
 
             <com.google.android.material.textview.MaterialTextView
                 style="?textAppearanceLabelLarge"
@@ -463,9 +370,9 @@
                     android:layout_width="0dp"
                     android:layout_height="0dp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintHeight_max="300dp"
                     app:layout_constraintDimensionRatio="@fraction/chartRatio"
                     app:layout_constraintEnd_toStartOf="@id/manga_stats_status_recycler_view"
+                    app:layout_constraintHeight_max="300dp"
                     app:layout_constraintHorizontal_bias="0.0"
                     app:layout_constraintHorizontal_chainStyle="packed"
                     app:layout_constraintStart_toStartOf="parent"
@@ -474,15 +381,15 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/manga_stats_status_recycler_view"
                     android:layout_width="0dp"
-                    android:layout_marginStart="12dp"
                     android:layout_height="wrap_content"
-                    tools:listitem="@layout/list_chart_legend"
+                    android:layout_marginStart="12dp"
                     android:nestedScrollingEnabled="false"
                     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintStart_toEndOf="@id/manga_stats_status_pie_chart"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/manga_stats_status_pie_chart"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent" />
+                    tools:listitem="@layout/list_chart_legend" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -981,6 +981,7 @@
     <string name="titles_in_library">Titles in library</string>
     <string name="chapters_read">Read chapters</string>
     <string name="mean_score">Mean score</string>
+    <string name="mean_score_info">Average trackers score for each manga</string>
     <string name="tracked_titles">Tracked titles</string>
     <string name="downloaded_chapters">Downloaded chapters</string>
     <string name="tags">Tags</string>
@@ -988,6 +989,7 @@
     <string name="titles_in_global_update">Titles in global update</string>
     <string name="trackers">Trackers</string>
     <string name="read_duration">Read duration</string>
+    <string name="read_duration_info">Time spent in the reader, based on chapter history</string>
     <string name="manga_status_distribution">Status distribution</string>
     <string name="manga_score_distribution">Score distribution</string>
     <string name="view_detailed_statistics">View detailed statistics</string>


### PR DESCRIPTION
Just saw that the total read duration doesn't include all history, just the manga in library, so I changed that

And some visual changes:
- tweaked a bit the general stats in case there is a language with long words and to avoid setting the number of lines
- reorganized the stats to have more homogeneous description lines (not sure which is better between vertical centered or top, let me know if you have a preference)
- added tooltips for read duration and mean score
- converted the link to stats details to a button
- fixed the status distribution wrapping when the text + value are too long (wrap the description text instead of value now)

<img alt="Stats screen" src="https://user-images.githubusercontent.com/55888232/188877835-8123837a-c15c-4806-bad4-6d203e050168.png" width="50%" />

Also tweaked the details stats order to put the read duration higher
