### PR TITLE
Added option to sort books in library by oldest unread chapter (next unread chapter).

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
@@ -29,6 +29,18 @@ interface ChapterQueries : DbProvider {
         )
         .prepare()
 
+    fun getUnreadChapters(mangaId: Long?) = db.get()
+        .listOfObjects(Chapter::class.java)
+        .withQuery(
+            Query.builder()
+                .table(ChapterTable.TABLE)
+                .where("${ChapterTable.COL_MANGA_ID} = ?")
+                .whereArgs(mangaId)
+                .where("${ChapterTable.COL_READ} = 0")
+                .build(),
+        )
+        .prepare()
+
     fun getRecentChapters(search: String = "", offset: Int, isResuming: Boolean) = db.get()
         .listOfObjects(MangaChapter::class.java)
         .withQuery(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/MangaQueries.kt
@@ -220,6 +220,19 @@ interface MangaQueries : DbProvider {
         )
         .prepare()
 
+    /**
+     * Sorts Mangas by the release date of their next unread chapter.
+     */
+    fun getNextUnreadManga() = db.get()
+        .listOfObjects(Manga::class.java)
+        .withQuery(
+            RawQuery.builder()
+                .query(getNextUnreadChapterMangaQuery())
+                .observesTables(MangaTable.TABLE)
+                .build(),
+        )
+        .prepare()
+
     fun getTotalChapterManga() = db.get().listOfObjects(Manga::class.java)
         .withQuery(RawQuery.builder().query(getTotalChapterMangaQuery()).observesTables(MangaTable.TABLE).build()).prepare()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/RawQueries.kt
@@ -307,6 +307,22 @@ fun getLastFetchedMangaQuery() =
     ORDER BY max DESC
 """
 
+/**
+ * This maps Mangas to the date of the next unread chapter.
+ * The next unread chapter is the oldest unread chapter.
+ */
+fun getNextUnreadChapterMangaQuery() =
+    """
+    SELECT ${Manga.TABLE}.*, MIN(${Chapter.TABLE}.${Chapter.COL_DATE_UPLOAD}) AS min
+    FROM ${Manga.TABLE}
+    JOIN ${Chapter.TABLE}
+    ON ${Manga.TABLE}.${Manga.COL_ID} = ${Chapter.TABLE}.${Chapter.COL_MANGA_ID}
+    WHERE ${Chapter.TABLE}.${Chapter.COL_READ} = 0
+    AND ${Manga.TABLE}.${Manga.COL_FAVORITE} = 1
+    GROUP BY ${Manga.TABLE}.${Manga.COL_ID}
+    ORDER BY min DESC
+"""
+
 fun getTotalChapterMangaQuery() =
     """
     SELECT ${Manga.TABLE}.*

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryAdapter.kt
@@ -224,6 +224,12 @@ class LibraryCategoryAdapter(val controller: LibraryController?) :
                             "N/A"
                         }
                     }
+                    LibrarySort.NextUnread -> {
+                        val id = item.manga.id ?: return ""
+                        val unreadChapters = db.getUnreadChapters(id).executeAsBlocking()
+                        val last = unreadChapters.minOfOrNull { it.date_upload }
+                        context.timeSpanFromNow(R.string.next_unread_chapter_, last ?: 0)
+                    }
                     LibrarySort.LatestChapter -> {
                         context.timeSpanFromNow(R.string.updated_, item.manga.last_update)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -444,6 +444,11 @@ class LibraryPresenter(
             db.getLastFetchedManga().executeAsBlocking().associate { it.id!! to counter++ }
         }
 
+        val nextUnreadManga by lazy {
+            var counter = 0
+            db.getNextUnreadManga().executeAsBlocking().associate { it.id!! to counter++ }
+        }
+
         val sortFn: (LibraryItem, LibraryItem) -> Int = { i1, i2 ->
             if (i1.header.category.id == i2.header.category.id) {
                 val category = i1.header.category
@@ -494,6 +499,13 @@ class LibraryPresenter(
                                 } else {
                                     sortAlphabetical(i1, i2)
                                 }
+                            }
+                            LibrarySort.NextUnread -> {
+                                val manga1NextUnread =
+                                    nextUnreadManga[i1.manga.id!!] ?: nextUnreadManga.size
+                                val manga2NextUnread =
+                                    nextUnreadManga[i2.manga.id!!] ?: nextUnreadManga.size
+                                manga1NextUnread.compareTo(manga2NextUnread)
                             }
                         }
                         if (!category.isAscending()) sort *= -1

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySort.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibrarySort.kt
@@ -28,7 +28,8 @@ enum class LibrarySort(
         7,
         R.string.category,
         R.drawable.ic_label_outline_24dp,
-    )
+    ),
+    NextUnread(8, R.string.next_unread_chapter, R.drawable.ic_next_unread_24dp),
     ;
 
     val categoryValue: Char
@@ -44,7 +45,7 @@ enum class LibrarySort(
     fun iconRes(isDynamic: Boolean) = if (isDynamic) dynamicIconRes else iconRes
 
     val hasInvertedSort: Boolean
-        get() = this in listOf(LastRead, DateAdded, LatestChapter, DateFetched)
+        get() = this in listOf(LastRead, DateAdded, LatestChapter, DateFetched, NextUnread)
 
     fun menuSheetItem(isDynamic: Boolean): MaterialMenuSheet.MenuSheetItem {
         return MaterialMenuSheet.MenuSheetItem(

--- a/app/src/main/res/drawable/ic_next_unread_24dp.xml
+++ b/app/src/main/res/drawable/ic_next_unread_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9c1.7,0 3,1.3 3,3s-1.3,3 -3,3s-3,-1.3 -3,-3S10.3,9 12,9M12,17c0.5,0 1,-0.1 1.4,-0.2C13.1,17.5 13,18.2 13,19v0.5l-1,0c-5,0 -9.3,-3.1 -11,-7.5c1.7,-4.4 6,-7.5 11,-7.5s9.3,3.1 11,7.5c-0.2,0.6 -0.6,1.3 -0.9,1.9c-0.9,-0.5 -2,-0.9 -3.1,-0.9c-0.8,0 -1.5,0.1 -2.2,0.4C16.9,13 17,12.5 17,12c0,-2.8 -2.2,-5 -5,-5s-5,2.2 -5,5S9.2,17 12,17zM18,15.9h1.8V20l1.6,-1.6l1.1,1.1l-3.6,3.6l-3.6,-3.6l1.1,-1.1L18,20V15.9z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,6 +167,7 @@
     <string name="date_fetched">Date fetched</string>
     <string name="latest_chapter">Latest chapter</string>
     <string name="drag_and_drop">Drag &amp; Drop</string>
+    <string name="next_unread_chapter">Next unread chapter</string>
 
     <!-- Library Display -->
     <string name="display_options">Display options</string>
@@ -252,6 +253,7 @@
         chapter. Are you sure?</string>
     <string name="reset_all_chapters_for_this_">Reset all chapters for this %1$s</string>
     <string name="last_read_">Last read %1$s</string>
+    <string name="next_unread_chapter_">Next unread chapter %1$s</string>
     <string name="read_">Read %1$s</string>
     <string name="updated_">Updated %1$s</string>
     <string name="added_">Added %1$s</string>


### PR DESCRIPTION
This closes feature request #1443, posted by me a few days ago. This aims to make it easier for users to read chapters across multiple series in release order.

This involves a few additional functions for the SQL queries and the new option in the UI.

## Tests
I tested that the ascending/descending order matches the already existing "last updated" order, in the case where those are the same (when the only unread chapter is the latest chapter). For titles with no unread chapters, the behavior is to default to alphabetical, like other similar sorting options.

## Possible alternative
This implementation interprets "next" as "oldest unread chapter". If a user skipped chapters, that's not quite the case. However, this interpretation matches the current behavior for clicking the open book button in the library (opens to the oldest unread chapter).   
An alternative approach would be to find the actual latest chapter read in the user history, then find the next chapter from there.