### PR TITLE
Fix stats range changed when using arrows

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsController.kt
@@ -368,10 +368,7 @@ class StatsDetailsController :
      * @param toAdd whether to add or remove
      */
     private fun changeReadDurationPeriod(toAdd: Int) {
-        val millionSeconds = presenter.endDate.timeInMillis - presenter.startDate.timeInMillis
-        val days = TimeUnit.MILLISECONDS.toDays(millionSeconds) + 1
-        presenter.startDate.add(Calendar.DAY_OF_YEAR, toAdd * days.toInt())
-        presenter.updateReadDurationPeriod(presenter.startDate.timeInMillis, days.toInt())
+        presenter.changeReadDurationPeriod(toAdd)
         binding.progress.isVisible = true
         jobReadDuration = viewScope.launchIO {
             presenter.updateMangaHistory()
@@ -498,7 +495,6 @@ class StatsDetailsController :
             progress.isVisible = true
             scrollView.isInvisible = true
             scrollView.scrollTo(0, 0)
-            chartLinearLayout?.isVisible = false
             statsPieChart.isVisible = false
             statsBarChart.isVisible = false
             statsLineChart.isVisible = false
@@ -521,7 +517,6 @@ class StatsDetailsController :
                 binding.noChartData.show(R.drawable.ic_heart_off_24dp, R.string.no_data_for_filters)
                 presenter.currentStats?.removeAll { it.count == 0 }
                 handleNoChartLayout()
-                chartLinearLayout?.isVisible = false
                 statsPieChart.isVisible = false
                 statsBarChart.isVisible = false
                 statsLineChart.isVisible = false
@@ -758,7 +753,6 @@ class StatsDetailsController :
             statsPieChart.clear()
             statsPieChart.invalidate()
 
-            chartLinearLayout?.isVisible = true
             statsPieChart.isVisible = true
             statsBarChart.isVisible = false
             statsLineChart.isVisible = false
@@ -795,7 +789,6 @@ class StatsDetailsController :
             statsBarChart.axisLeft.resetAxisMinimum()
             statsBarChart.axisLeft.resetAxisMaximum()
 
-            chartLinearLayout?.isVisible = true
             statsPieChart.isVisible = false
             statsBarChart.isVisible = true
             statsLineChart.isVisible = false
@@ -908,7 +901,6 @@ class StatsDetailsController :
             statsLineChart.clear()
             statsLineChart.invalidate()
 
-            chartLinearLayout?.isVisible = true
             statsPieChart.isVisible = false
             statsBarChart.isVisible = false
             statsLineChart.isVisible = true

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/stats/details/StatsDetailsPresenter.kt
@@ -68,6 +68,7 @@ class StatsDetailsPresenter(
         timeInMillis = startDate.timeInMillis - 1
         add(Calendar.WEEK_OF_YEAR, 1)
     }
+    private var daysRange = getDaysRange()
     var history = getMangaHistoryGroupedByDay()
     var historyByDayAndManga = emptyMap<Calendar, Map<Manga, List<History>>>()
 
@@ -555,9 +556,7 @@ class StatsDetailsPresenter(
             timeInMillis = startDate.timeInMillis
         }
 
-        val millionSeconds = endDate.timeInMillis - startDate.timeInMillis
-        val days = TimeUnit.MILLISECONDS.toDays(millionSeconds)
-        return (0..days).associate { _ ->
+        return (0 until daysRange).associate { _ ->
             Calendar.getInstance().apply { timeInMillis = calendar.timeInMillis } to history.filter {
                 val calH = Calendar.getInstance().apply { timeInMillis = it.history.last_read }
                 calH.get(Calendar.DAY_OF_YEAR) == calendar.get(Calendar.DAY_OF_YEAR) &&
@@ -578,27 +577,18 @@ class StatsDetailsPresenter(
         } ?: context.getString(R.string.unknown)
     }
 
+    fun changeReadDurationPeriod(toAdd: Int) {
+        startDate.add(Calendar.DAY_OF_YEAR, toAdd * daysRange.toInt())
+        endDate.add(Calendar.DAY_OF_YEAR, toAdd * daysRange.toInt())
+    }
+
+    private fun getDaysRange(): Long {
+        return TimeUnit.MILLISECONDS.toDays(endDate.timeInMillis - startDate.timeInMillis) + 1
+    }
+
     /**
-     * Update the start date and end date according to time selected and fetch the history of the period
+     * Update the start date and end date according to time selected
      */
-    fun updateReadDurationPeriod(millis: Long, days: Int) {
-        startDate = Calendar.getInstance().apply {
-            timeInMillis = millis
-            set(Calendar.HOUR_OF_DAY, 0)
-            clear(Calendar.MINUTE)
-            clear(Calendar.SECOND)
-            clear(Calendar.MILLISECOND)
-        }
-        endDate = Calendar.getInstance().apply {
-            timeInMillis = startDate.timeInMillis - 1
-            add(Calendar.DAY_OF_YEAR, days)
-        }
-    }
-
-    fun updateMangaHistory() {
-        history = getMangaHistoryGroupedByDay()
-    }
-
     fun updateReadDurationPeriod(startMillis: Long, endMillis: Long) {
         startDate = Calendar.getInstance().apply {
             timeInMillis = startMillis
@@ -616,6 +606,11 @@ class StatsDetailsPresenter(
             add(Calendar.DAY_OF_YEAR, 1)
             timeInMillis -= 1
         }
+        daysRange = getDaysRange()
+    }
+
+    fun updateMangaHistory() {
+        history = getMangaHistoryGroupedByDay()
     }
 
     fun convertCalendarToLongString(calendar: Calendar): String {

--- a/app/src/main/res/layout-land/stats_details_controller.xml
+++ b/app/src/main/res/layout-land/stats_details_controller.xml
@@ -7,25 +7,12 @@
     android:layout_height="match_parent"
     tools:context="eu.kanade.tachiyomi.ui.more.stats.details.StatsDetailsController">
 
-    <eu.kanade.tachiyomi.widget.EmptyView
-        android:id="@+id/no_chart_data"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:layout_gravity="center"
-        android:visibility="gone" />
-
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/filter_constraint_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/stats_details_scroll_view"
         app:layout_constraintStart_toStartOf="parent">
 
         <HorizontalScrollView
@@ -288,6 +275,17 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>
+
+    <eu.kanade.tachiyomi.widget.EmptyView
+        android:id="@+id/no_chart_data"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@id/chart_linear_layout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_gravity="center"
+        android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/stats_recycler_view"


### PR DESCRIPTION
Fix weird behavior when changing the stats period too fast which increased the days range + disappearance of the date picker/arrows when `no_chart_data` was displayed in landscape