### PR TITLE
Recreate presenterScope in BaseCoroutinePresenter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/presenter/BaseCoroutinePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/presenter/BaseCoroutinePresenter.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import java.lang.ref.WeakReference
 
 open class BaseCoroutinePresenter<T> {
@@ -19,6 +20,9 @@ open class BaseCoroutinePresenter<T> {
      */
     open fun attachView(view: T?) {
         weakView = WeakReference(view)
+         if (!presenterScope.isActive) {
+            presenterScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        }
     }
 
     open fun onCreate() {


### PR DESCRIPTION
If the BaseCoroutineController is destroyed, it calls destroy on the presenter, but the presenter isn't necessarily gone.  So when a view gets resumed, the presenter now has a cancelled scope