### PR TITLE
Category filter for remove after read

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -264,7 +264,7 @@ class PreferencesHelper(val context: Context) {
 
     fun backupInterval() = flowPrefs.getInt(Keys.backupInterval, 0)
 
-    fun removeAfterReadSlots() = prefs.getInt(Keys.removeAfterReadSlots, -1)
+    fun removeAfterReadSlots() = flowPrefs.getInt(Keys.removeAfterReadSlots, -1)
 
     fun removeAfterMarkedAsRead() = prefs.getBoolean(Keys.removeAfterMarkedAsRead, false)
 
@@ -410,6 +410,10 @@ class PreferencesHelper(val context: Context) {
     fun deleteRemovedChapters() = flowPrefs.getInt(Keys.deleteRemovedChapters, 0)
 
     fun removeBookmarkedChapters() = flowPrefs.getBoolean("pref_remove_bookmarked", false)
+
+    fun removeReadChaptersInCategories() = flowPrefs.getStringSet("remove_read_categories", emptySet())
+
+    fun excludeCategoriesInRemoveRead() = flowPrefs.getStringSet("remove_read_categories_exclude", emptySet())
 
     fun showAllCategories() = flowPrefs.getBoolean("show_all_categories", true)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -411,9 +411,7 @@ class PreferencesHelper(val context: Context) {
 
     fun removeBookmarkedChapters() = flowPrefs.getBoolean("pref_remove_bookmarked", false)
 
-    fun removeReadChaptersInCategories() = flowPrefs.getStringSet("remove_read_categories", emptySet())
-
-    fun excludeCategoriesInRemoveRead() = flowPrefs.getStringSet("remove_read_categories_exclude", emptySet())
+    fun removeExcludeCategories() = flowPrefs.getStringSet("remove_exclude_categories", emptySet())
 
     fun showAllCategories() = flowPrefs.getBoolean("show_all_categories", true)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -571,16 +571,13 @@ class ReaderViewModel(
         }
         // Check if deleting option is enabled and chapter exists
         if (removeAfterReadSlots != -1 && chapterToDelete != null) {
-            val includedCategories = preferences.removeReadChaptersInCategories().get().map(String::toInt)
-            val excludedCategories = preferences.excludeCategoriesInRemoveRead().get().map(String::toInt)
-            if (includedCategories.any() || excludedCategories.any()) {
+            val excludedCategories = preferences.removeExcludeCategories().get().map(String::toInt)
+            if (excludedCategories.any()) {
                 val categories = db.getCategoriesForManga(manga!!).executeAsBlocking()
                     .mapNotNull { it.id }
-                    .takeUnless { it.isEmpty() } ?: listOf(0)
+                    .ifEmpty { listOf(0) }
 
                 if (categories.any { it in excludedCategories }) return
-
-                if (includedCategories.any() && categories.none { it in includedCategories }) return
             }
 
             enqueueDeleteReadChapters(chapterToDelete)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -561,7 +561,7 @@ class ReaderViewModel(
     private fun deleteChapterIfNeeded(currentChapter: ReaderChapter) {
         // Determine which chapter should be deleted and enqueue
         val currentChapterPosition = chapterList.indexOf(currentChapter)
-        val removeAfterReadSlots = preferences.removeAfterReadSlots()
+        val removeAfterReadSlots = preferences.removeAfterReadSlots().get()
         val chapterToDelete = chapterList.getOrNull(currentChapterPosition - removeAfterReadSlots)
 
         if (removeAfterReadSlots != 0 && chapterToDownload != null) {
@@ -571,6 +571,18 @@ class ReaderViewModel(
         }
         // Check if deleting option is enabled and chapter exists
         if (removeAfterReadSlots != -1 && chapterToDelete != null) {
+            val includedCategories = preferences.removeReadChaptersInCategories().get().map(String::toInt)
+            val excludedCategories = preferences.excludeCategoriesInRemoveRead().get().map(String::toInt)
+            if (includedCategories.any() || excludedCategories.any()) {
+                val categories = db.getCategoriesForManga(manga!!).executeAsBlocking()
+                    .mapNotNull { it.id }
+                    .takeUnless { it.isEmpty() } ?: listOf(0)
+
+                if (categories.any { it in excludedCategories }) return
+
+                if (includedCategories.any() && categories.none { it in includedCategories }) return
+            }
+
             enqueueDeleteReadChapters(chapterToDelete)
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -55,6 +55,9 @@ class SettingsDownloadController : SettingsController() {
             summaryRes = R.string.split_tall_images_summary
         }
 
+        val dbCategories = db.getCategories().executeAsBlocking()
+        val categories = listOf(Category.createDefault(context)) + dbCategories
+
         preferenceCategory {
             titleRes = R.string.remove_after_read
 
@@ -64,7 +67,7 @@ class SettingsDownloadController : SettingsController() {
                 defaultValue = false
             }
             intListPreference(activity) {
-                key = Keys.removeAfterReadSlots
+                bindTo(preferences.removeAfterReadSlots())
                 titleRes = R.string.remove_after_read
                 entriesRes = arrayOf(
                     R.string.never,
@@ -77,14 +80,22 @@ class SettingsDownloadController : SettingsController() {
                 entryRange = -1..4
                 defaultValue = -1
             }
+            triStateListPreference(activity) {
+                preferences.apply {
+                    bindTo(removeReadChaptersInCategories(), excludeCategoriesInRemoveRead())
+                }
+                titleRes = R.string.categories
+                entries = categories.map { it.name }
+                entryValues = categories.map { it.id.toString() }
+                allSelectionRes = R.string.all
+
+                preferences.removeAfterReadSlots().asImmediateFlowIn(viewScope) { isVisible = it != -1 }
+            }
             switchPreference {
                 bindTo(preferences.removeBookmarkedChapters())
                 titleRes = R.string.allow_deleting_bookmarked_chapters
             }
         }
-
-        val dbCategories = db.getCategories().executeAsBlocking()
-        val categories = listOf(Category.createDefault(context)) + dbCategories
 
         preferenceCategory {
             titleRes = R.string.download_new_chapters

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsDownloadController.kt
@@ -80,15 +80,12 @@ class SettingsDownloadController : SettingsController() {
                 entryRange = -1..4
                 defaultValue = -1
             }
-            triStateListPreference(activity) {
-                preferences.apply {
-                    bindTo(removeReadChaptersInCategories(), excludeCategoriesInRemoveRead())
-                }
-                titleRes = R.string.categories
+            multiSelectListPreferenceMat(activity) {
+                bindTo(preferences.removeExcludeCategories())
+                titleRes = R.string.pref_remove_exclude_categories
                 entries = categories.map { it.name }
                 entryValues = categories.map { it.id.toString() }
-                allSelectionRes = R.string.all
-
+                noSelectionRes = R.string.none
                 preferences.removeAfterReadSlots().asImmediateFlowIn(viewScope) { isVisible = it != -1 }
             }
             switchPreference {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -969,6 +969,7 @@
     <string name="remove_when_marked_as_read">Remove when marked as read</string>
     <string name="allow_deleting_bookmarked_chapters">Allow deleting bookmarked chapters</string>
     <string name="remove_after_read">Remove after read</string>
+    <string name="pref_remove_exclude_categories">Excluded categories</string>
     <string name="custom_location">Custom location</string>
     <string name="last_read_chapter">Last read chapter</string>
     <string name="second_to_last">Second to last chapter</string>


### PR DESCRIPTION
Adds a category filter for the `Remove after read` setting so that downloaded chapters are only deleted after being read in the configured categories. Resolves #1593 
It does not change how `Remove when marked as read` works, so that still deletes chapters in all categories
| Remove after read disabled | Enabled|
|--------|--------|
| ![image](https://github.com/Jays2Kings/tachiyomiJ2K/assets/31808958/ce299e71-75ba-4caf-b97e-42dc40a14131) | ![image](https://github.com/Jays2Kings/tachiyomiJ2K/assets/31808958/2e29f7ac-ae91-412b-be7e-5dece2b2bd54) | 