### PR TITLE
Config to disable warnings for large updates

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -365,7 +365,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
             .groupBy { it.source }
             .filterKeys { sourceManager.get(it) !is UnmeteredSource }
             .maxOfOrNull { it.value.size } ?: 0
-        if (largestSourceSize > MANGA_PER_SOURCE_QUEUE_WARNING_THRESHOLD) {
+        if (largestSourceSize > MANGA_PER_SOURCE_QUEUE_WARNING_THRESHOLD && !preferences.disableNotificationSizeWarning().get()) {
             notifier.showQueueSizeWarningNotification()
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -242,6 +242,8 @@ object PreferenceKeys {
 
     const val chaptersDescAsDefault = "chapters_desc_as_default"
 
+    const val disableNotificationSizeWarning = "disable_notification_size_warning"
+
     fun trackUsername(syncId: Int) = "pref_mangasync_username_$syncId"
 
     fun trackPassword(syncId: Int) = "pref_mangasync_password_$syncId"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -495,4 +495,6 @@ class PreferencesHelper(val context: Context) {
     fun coverColors() = flowPrefs.getStringSet(Keys.coverColors, emptySet())
 
     fun useStaggeredGrid() = flowPrefs.getBoolean("use_staggered_grid", false)
+
+    fun disableNotificationSizeWarning() = flowPrefs.getBoolean(Keys.disableNotificationSizeWarning, false)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsGeneralController.kt
@@ -85,6 +85,11 @@ class SettingsGeneralController : SettingsController() {
                 }
             }
         }
+        switchPreference {
+            key = Keys.disableNotificationSizeWarning
+            titleRes = R.string.disable_notification_size_warning
+            defaultValue = false
+        }
 
         preferenceCategory {
             titleRes = R.string.app_shortcuts

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -756,6 +756,7 @@
     <string name="over_any_network">Over any network</string>
     <string name="dont_auto_update">Don\'t auto-update</string>
     <string name="language_requires_app_restart">Some languages may require an app relaunch to display correctly</string>
+    <string name="disable_notification_size_warning">Disable warnings for large updates</string>
 
     <string name="app_shortcuts">App shortcuts</string>
     <string name="show_recent_sources">Show recently used sources</string>


### PR DESCRIPTION
Resolves #1581 
This PR adds a config switch to disable the "Large updates ..." warning.
![image](https://github.com/Jays2Kings/tachiyomiJ2K/assets/31808958/78e457de-7c96-49c9-8d1f-624074d6dd9a)
It is currently in the General settings menu, is that ok or should it be moved to the Library settings menu?