### PR TITLE
add extension info to crashlog

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -7,11 +7,15 @@ import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.extension.ExtensionManager
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notificationManager
 import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import java.io.IOException
 
 class CrashLogUtil(private val context: Context) {
@@ -19,16 +23,20 @@ class CrashLogUtil(private val context: Context) {
     private val notificationBuilder = context.notificationBuilder(Notifications.CHANNEL_CRASH_LOGS) {
         setSmallIcon(R.drawable.ic_tachij2k_notification)
     }
+    val extensionManager = ExtensionManager(context) // Instantiate the ExtensionManager
 
     fun dumpLogs() {
-        try {
-            val file = context.createFileInCacheDir("tachiyomi_crash_logs.txt")
-            file.appendText(getDebugInfo() + "\n\n")
-            Runtime.getRuntime().exec("logcat *:E -d -f ${file.absolutePath}")
-
-            showNotification(file.getUriCompat(context))
-        } catch (e: IOException) {
-            context.toast("Failed to get logs")
+        val scope = CoroutineScope(Dispatchers.IO)
+        scope.launch {
+            try {
+                val file = context.createFileInCacheDir("tachiyomi_crash_logs.txt")
+                file.appendText(getDebugInfo() + "\n\n")
+                file.appendText(getExtensionsInfo() + "\n\n")
+                Runtime.getRuntime().exec("logcat *:E -d -f ${file.absolutePath}")
+                showNotification(file.getUriCompat(context))
+            } catch (e: IOException) {
+                context.toast("Failed to get logs")
+            }
         }
     }
     fun getDebugInfo(): String {
@@ -43,6 +51,33 @@ class CrashLogUtil(private val context: Context) {
             Device product name: ${Build.PRODUCT}
         """.trimIndent()
     }
+
+    suspend fun getExtensionsInfo(): String {
+        extensionManager.findAvailableExtensions()
+        val installedExtensions = extensionManager.installedExtensionsFlow.value
+        val availableExtensions = extensionManager.availableExtensionsFlow.value
+
+        val extensionInfoList = mutableListOf<String>()
+
+        for (installedExtension in installedExtensions) {
+            val availableExtension = availableExtensions.find { it.pkgName == installedExtension.pkgName }
+
+            val hasUpdate = availableExtension?.versionCode ?: 0 > installedExtension.versionCode
+            if (hasUpdate || installedExtension.isObsolete) {
+                val extensionInfo =
+                    "Extension Name: ${installedExtension.name}\n" +
+                        "Installed Version: ${installedExtension.versionName}\n" +
+                        "Available Version: ${availableExtension?.versionName ?: "N/A"}\n" +
+                        "Obsolete: ${installedExtension.isObsolete}\n"
+                extensionInfoList.add(extensionInfo)
+            }
+        }
+        if (extensionInfoList.isNotEmpty()) {
+            extensionInfoList.add(0, "Extensions that are outdated or obsolete")
+        }
+        return extensionInfoList.joinToString("\n")
+    }
+
     private fun showNotification(uri: Uri) {
         context.notificationManager.cancel(Notifications.ID_CRASH_LOGS)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -16,6 +16,8 @@ import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.io.IOException
 
 class CrashLogUtil(private val context: Context) {
@@ -23,10 +25,9 @@ class CrashLogUtil(private val context: Context) {
     private val notificationBuilder = context.notificationBuilder(Notifications.CHANNEL_CRASH_LOGS) {
         setSmallIcon(R.drawable.ic_tachij2k_notification)
     }
-    val extensionManager = ExtensionManager(context) // Instantiate the ExtensionManager
 
+    val scope = CoroutineScope(Dispatchers.IO)
     fun dumpLogs() {
-        val scope = CoroutineScope(Dispatchers.IO)
         scope.launch {
             try {
                 val file = context.createFileInCacheDir("tachiyomi_crash_logs.txt")
@@ -53,6 +54,7 @@ class CrashLogUtil(private val context: Context) {
     }
 
     suspend fun getExtensionsInfo(): String {
+        val extensionManager: ExtensionManager = Injekt.get()
         extensionManager.findAvailableExtensions()
         val installedExtensions = extensionManager.installedExtensionsFlow.value
         val availableExtensions = extensionManager.availableExtensionsFlow.value
@@ -79,8 +81,8 @@ class CrashLogUtil(private val context: Context) {
     }
 
     private fun showNotification(uri: Uri) {
+        ExtensionManager(context)
         context.notificationManager.cancel(Notifications.ID_CRASH_LOGS)
-
         with(notificationBuilder) {
             setContentTitle(context.getString(R.string.crash_log_saved))
 


### PR DESCRIPTION
This adds extension info that is obsolete or out of date to the crashlog. It looks like
![image](https://github.com/Jays2Kings/tachiyomiJ2K/assets/103472524/e1d22ece-f251-49c6-84f0-190e7c91ee4c)
