### PR TITLE
kotlin agp gradle update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,6 @@
 import java.io.ByteArrayOutputStream
+import org.gradle.api.tasks.Copy
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     id(Plugins.androidApplication)
@@ -120,9 +122,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
     }
+
     namespace = "eu.kanade.tachiyomi"
 }
 
@@ -279,7 +284,7 @@ dependencies {
     implementation("dev.rikka.shizuku:api:$shizukuVersion")
     implementation("dev.rikka.shizuku:provider:$shizukuVersion")
 
-    implementation(kotlin("stdlib", org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION))
+    implementation(kotlin("stdlib"))
 
     val coroutines = "1.10.2"
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupCreator.kt
@@ -26,7 +26,6 @@ import eu.kanade.tachiyomi.data.backup.models.BackupChapter
 import eu.kanade.tachiyomi.data.backup.models.BackupHistory
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupPreference
-import eu.kanade.tachiyomi.data.backup.models.BackupSerializer
 import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
 import eu.kanade.tachiyomi.data.backup.models.BackupTracking
@@ -129,7 +128,7 @@ class BackupCreator(
                 throw IllegalStateException("Failed to get handle on file")
             }
 
-            val byteArray = parser.encodeToByteArray(BackupSerializer, backup!!)
+            val byteArray = parser.encodeToByteArray(Backup.serializer(), backup!!)
             if (byteArray.isEmpty()) {
                 throw IllegalStateException(context.getString(R.string.empty_backup_error))
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupSerializer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupSerializer.kt
@@ -1,6 +1,0 @@
-package eu.kanade.tachiyomi.data.backup.models
-
-import kotlinx.serialization.Serializer
-
-@Serializer(forClass = Backup::class)
-object BackupSerializer

--- a/app/src/main/java/eu/kanade/tachiyomi/util/BackupUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/BackupUtil.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.net.Uri
 import eu.kanade.tachiyomi.data.backup.BackupCreator
 import eu.kanade.tachiyomi.data.backup.models.Backup
-import eu.kanade.tachiyomi.data.backup.models.BackupSerializer
 import okio.buffer
 import okio.gzip
 import okio.source
@@ -37,6 +36,6 @@ object BackupUtil {
                 backupStringSource
             }.use { it.readByteArray() }
 
-        return backupCreator.parser.decodeFromByteArray(BackupSerializer, backupString)
+        return backupCreator.parser.decodeFromByteArray(Backup.serializer(), backupString)
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,12 +25,13 @@ subprojects {
 
 buildscript {
     dependencies {
-        classpath("com.android.tools.build:gradle:8.9.2")
-        classpath("com.google.gms:google-services:4.4.2")
+        //noinspection AndroidGradlePluginVersion
+        classpath("com.android.tools.build:gradle:8.13.2")
+        classpath("com.google.gms:google-services:4.4.4")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${AndroidVersions.kotlin}")
-        classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")
+        classpath("com.google.android.gms:oss-licenses-plugin:0.10.10")
         classpath("org.jetbrains.kotlin:kotlin-serialization:${AndroidVersions.kotlin}")
-        classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.3")
+        classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.6")
     }
     repositories {
         gradlePluginPortal()

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -7,7 +7,7 @@ object AndroidVersions {
     const val versionCode = 111
     const val versionName = "1.7.4"
     const val ndk = "23.1.7779620"
-    const val kotlin = "2.1.20"
+    const val kotlin = "2.3.10"
 }
 
 object Plugins {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
this fixes some newer exts from a certain ext repo that now requires kotlin 2.3.0

I tested it and it builds and works and fixes the error, should be good to merg

gradle yelled at me about your build script using .exec and about the Hebrew string copying task, those things are deprecated apparently, you may want to update them yourself later