### PR TITLE
Webtoon reader: Add "Fit to screen" double-tap zoom option

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -88,6 +88,8 @@ object PreferenceKeys {
 
     const val webtoonEnableZoomOut = "webtoon_enable_zoom_out"
 
+    const val webtoonDoubleTapZoom = "webtoon_double_tap_zoom"
+
     const val autoUpdateTrack = "pref_auto_update_manga_sync_key"
 
     const val trackMarkedAsRead = "track_marked_as_read"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -182,6 +182,8 @@ class PreferencesHelper(
 
     fun webtoonEnableZoomOut() = flowPrefs.getBoolean(Keys.webtoonEnableZoomOut, false)
 
+    fun webtoonDoubleTapZoom() = flowPrefs.getInt(Keys.webtoonDoubleTapZoom, 0)
+
     fun readWithLongTap() = flowPrefs.getBoolean(Keys.readWithLongTap, true)
 
     fun readWithVolumeKeys() = flowPrefs.getBoolean(Keys.readWithVolumeKeys, false)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/ReaderPagedView.kt
@@ -65,6 +65,7 @@ class ReaderPagedView
                     R.array.webtoon_side_padding_values,
                 )
                 webtoonEnableZoomOut.bindToPreference(preferences.webtoonEnableZoomOut())
+                webtoonDoubleTapZoom.bindToPreference(preferences.webtoonDoubleTapZoom())
                 webtoonNav.bindToPreference(preferences.navigationModeWebtoon())
                 webtoonInvert.bindToPreference(preferences.webtoonNavInverted())
                 webtoonPageLayout.bindToPreference(preferences.webtoonPageLayout())
@@ -98,6 +99,7 @@ class ReaderPagedView
                 binding.cropBordersWebtoon,
                 binding.webtoonSidePadding,
                 binding.webtoonEnableZoomOut,
+                binding.webtoonDoubleTapZoom,
                 binding.webtoonNav,
                 binding.webtoonInvert,
                 binding.webtoonPageLayout,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonConfig.kt
@@ -36,7 +36,11 @@ class WebtoonConfig(
     var enableZoomOut = false
         private set
 
+    var doubleTapZoom = 0
+        private set
+
     var zoomPropertyChangedListener: ((Boolean) -> Unit)? = null
+    var doubleTapZoomChangedListener: ((Int) -> Unit)? = null
 
     var splitPages = preferences.webtoonPageLayout().get() == PageLayout.SPLIT_PAGES.webtoonValue
 
@@ -81,6 +85,10 @@ class WebtoonConfig(
         preferences
             .webtoonEnableZoomOut()
             .register({ enableZoomOut = it }, { zoomPropertyChangedListener?.invoke(it) })
+
+        preferences
+            .webtoonDoubleTapZoom()
+            .register({ doubleTapZoom = it }, { doubleTapZoomChangedListener?.invoke(it) })
 
         preferences
             .webtoonPageLayout()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonRecyclerView.kt
@@ -41,6 +41,8 @@ open class WebtoonRecyclerView
                 }
             }
 
+        var doubleTapZoom = 0
+
         private val minRate
             get() = if (canZoomOut) MIN_RATE else DEFAULT_RATE
 
@@ -111,6 +113,7 @@ open class WebtoonRecyclerView
             toX: Float,
             fromY: Float,
             toY: Float,
+            scrollByY: Int = 0,
         ) {
             isZooming = true
             val animatorSet = AnimatorSet()
@@ -122,9 +125,33 @@ open class WebtoonRecyclerView
 
             val scaleAnimator = ValueAnimator.ofFloat(fromRate, toRate)
             scaleAnimator.addUpdateListener { animation ->
-                setScaleRate(animation.animatedValue as Float)
+                val scale = animation.animatedValue as Float
+                setScaleRate(scale)
+
+                if (scale < 1f || fromRate < 1f) {
+                    layoutParams.height =
+                        if (scale < 1f) {
+                            (originalHeight / scale).toInt()
+                        } else {
+                            originalHeight
+                        }
+                    halfHeight = layoutParams.height / 2
+                    requestLayout()
+                }
             }
-            animatorSet.playTogether(translationXAnimator, translationYAnimator, scaleAnimator)
+            val animators = mutableListOf(translationXAnimator, translationYAnimator, scaleAnimator)
+            if (scrollByY != 0) {
+                val scrollAnimator = ValueAnimator.ofInt(0, scrollByY)
+                var previousScrollValue = 0
+                scrollAnimator.addUpdateListener { animation ->
+                    val currentValue = animation.animatedValue as Int
+                    val delta = currentValue - previousScrollValue
+                    previousScrollValue = currentValue
+                    scrollBy(0, delta)
+                }
+                animators.add(scrollAnimator)
+            }
+            animatorSet.playTogether(animators as Collection<Animator>)
             animatorSet.duration = ANIMATOR_DURATION_TIME.toLong()
             animatorSet.interpolator = DecelerateInterpolator()
             animatorSet.start()
@@ -249,7 +276,23 @@ open class WebtoonRecyclerView
             fun onDoubleTapConfirmed(ev: MotionEvent) {
                 if (!isZooming) {
                     if (scaleX != DEFAULT_RATE) {
-                        zoom(currentScale, DEFAULT_RATE, x, 0f, y, 0f)
+                        val scrollByY =
+                            if (currentScale < DEFAULT_RATE) {
+                                (ev.y * (1f / currentScale - 1f)).toInt()
+                            } else {
+                                0
+                            }
+                        zoom(currentScale, DEFAULT_RATE, x, 0f, y, 0f, scrollByY = scrollByY)
+                    } else if (doubleTapZoom == 1) {
+                        val child = findChildViewUnder(ev.x, ev.y)
+                        if (child != null && child.height > originalHeight) {
+                            val toScale =
+                                (originalHeight.toFloat() / child.height)
+                                    .coerceIn(MIN_RATE, DEFAULT_RATE)
+                            val targetHalfHeight = (originalHeight / toScale / 2).toInt()
+                            val toY = (originalHeight / 2f - targetHalfHeight)
+                            zoom(DEFAULT_RATE, toScale, 0f, 0f, 0f, toY, scrollByY = child.top)
+                        }
                     } else {
                         val toScale = 2f
                         val toX = (halfWidth - ev.x) * (toScale - 1)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -139,6 +139,10 @@ class WebtoonViewer(
             frame.enableZoomOut = it
         }
 
+        config.doubleTapZoomChangedListener = {
+            recycler.doubleTapZoom = it
+        }
+
         config.navigationModeChangedListener = {
             val showOnStart = config.navigationOverlayForNewUser
             activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsReaderController.kt
@@ -411,6 +411,18 @@ class SettingsReaderController : SettingsController() {
                     titleRes = R.string.enable_zoom_out
                     defaultValue = false
                 }
+
+                intListPreference(activity) {
+                    key = Keys.webtoonDoubleTapZoom
+                    titleRes = R.string.double_tap_zoom
+                    entriesRes =
+                        arrayOf(
+                            R.string.double_tap_zoom_in,
+                            R.string.double_tap_fit_to_screen,
+                        )
+                    entryValues = listOf(0, 1)
+                    defaultValue = "0"
+                }
             }
             preferenceCategory {
                 titleRes = R.string.navigation

--- a/app/src/main/res/layout/reader_paged_layout.xml
+++ b/app/src/main/res/layout/reader_paged_layout.xml
@@ -157,6 +157,14 @@
             app:layout_constraintTop_toBottomOf="@id/webtoon_side_padding" />
 
         <eu.kanade.tachiyomi.widget.MaterialSpinnerView
+            android:id="@+id/webtoon_double_tap_zoom"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:title="@string/double_tap_zoom"
+            android:entries="@array/double_tap_zoom" />
+
+        <eu.kanade.tachiyomi.widget.MaterialSpinnerView
             android:id="@+id/webtoon_page_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -127,6 +127,11 @@
         <item>@string/split_double_pages</item>
     </string-array>
 
+    <string-array name="double_tap_zoom">
+        <item>@string/double_tap_zoom_in</item>
+        <item>@string/double_tap_fit_to_screen</item>
+    </string-array>
+
     <string-array name="invert_tapping_mode">
         <item>@string/none</item>
         <item>@string/horizontally</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -423,6 +423,9 @@
     <string name="fullscreen">Fullscreen</string>
     <string name="animate_page_transitions">Animate page transitions</string>
     <string name="enable_zoom_out">Enable zoom out</string>
+    <string name="double_tap_zoom">Double-tap zoom</string>
+    <string name="double_tap_zoom_in">Zoom in</string>
+    <string name="double_tap_fit_to_screen">Fit to screen</string>
     <string name="double_tap_anim_speed">Double tap animation speed</string>
     <string name="show_page_number">Show page number</string>
     <string name="true_32bit_color">32-bit color</string>


### PR DESCRIPTION
## Feature Description

Adds a **"Double-tap zoom"** dropdown to webtoon reader settings (Settings > Reader > Webtoon) with two options:

- **Zoom in** (default): existing behavior, double-tap zooms to 2× centered on tap position
- **Fit to screen**: double-tap zooms out to fit a tall panel entirely on screen

### Why this is useful

On foldable devices and tablets (e.g. OnePlus Open, Galaxy Fold, iPads) in portrait mode, many webtoon panels are significantly taller than the screen. Readers have to scroll through each panel individually, losing the ability to see the full panel composition at once.

"Fit to screen" lets you double-tap a tall panel to shrink it so the full panel fits on screen, similar to how you'd pinch-to-zoom-out, but with a single consistent double-tap. Double-tap again to zoom back to normal reading size.

This is especially helpful for:
- **Wide-screen / foldable devices** where the aspect ratio makes panels very tall relative to screen height
- **Panels with full-page art** where seeing the entire composition matters
- **Possibility to zoom-out** without the need to pinch. Better for one-handed reading.

### How it works

- Scale is calculated dynamically per panel (`screen height / panel height`), clamped between 0.5× and 1.0×
- Only activates on panels taller than the screen; shorter panels are unaffected
- Zoom, translation, and scroll to panel top are synchronized in a single animation
- When zoomed out, double-tapping zooms back to 1× at the tapped Y position (not the panel top), so you resume where you tapped
- Works independently of the existing "Enable zoom out" (pinch) setting

### Screencapture

https://github.com/user-attachments/assets/9999728a-83b1-4bc7-aef2-728f3b8e8fcd

### Changes

10 files changed across preferences, config, viewer, settings UI, and resources.