### PR TITLE
Show "Duplicated" Badge for entries already in library from another extension

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -489,7 +489,7 @@ class PreferencesHelper(
 
     fun hideInLibraryItems() = flowPrefs.getBoolean("browse_hide_in_library_items", false)
 
-    fun showDuplicatedInLibraryItems() = flowPrefs.getBoolean("browse_show_duplicated_in_library_items", false)
+    fun showDuplicateInLibraryItems() = flowPrefs.getBoolean("browse_show_duplicate_in_library_items", false)
 
     // Tutorial preferences
     fun shownFilterTutorial() = flowPrefs.getBoolean("shown_filter_tutorial", false)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -489,6 +489,8 @@ class PreferencesHelper(
 
     fun hideInLibraryItems() = flowPrefs.getBoolean("browse_hide_in_library_items", false)
 
+    fun showDuplicatedInLibraryItems() = flowPrefs.getBoolean("browse_show_duplicated_in_library_items", false)
+
     // Tutorial preferences
     fun shownFilterTutorial() = flowPrefs.getBoolean("shown_filter_tutorial", false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
@@ -219,4 +219,17 @@ class LibraryBadge
                         ColorStateList.valueOf(context.getResourceColor(R.attr.colorPrimary))
                 }
         }
+
+        fun setDuplicatedInLibrary(duplicatedInLibrary: Boolean) {
+            this.isVisible = duplicatedInLibrary
+            binding.unreadAngle.isVisible = false
+            binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
+            binding.unreadText.isVisible = duplicatedInLibrary
+            binding.unreadText.text = resources.getText(R.string.duplicated_in_library)
+            binding.unreadText.background =
+                MaterialShapeDrawable(makeShapeCorners(ogRadius, ogRadius)).apply {
+                    this.fillColor =
+                        ColorStateList.valueOf(context.getResourceColor(R.attr.colorSecondary))
+                }
+        }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
@@ -220,12 +220,12 @@ class LibraryBadge
                 }
         }
 
-        fun setDuplicatedInLibrary(duplicatedInLibrary: Boolean) {
-            this.isVisible = duplicatedInLibrary
+        fun setDuplicateInLibrary(duplicateInLibrary: Boolean) {
+            this.isVisible = duplicateInLibrary
             binding.unreadAngle.isVisible = false
             binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
-            binding.unreadText.isVisible = duplicatedInLibrary
-            binding.unreadText.text = resources.getText(R.string.duplicated_in_library)
+            binding.unreadText.isVisible = duplicateInLibrary
+            binding.unreadText.text = resources.getText(R.string.duplicate_in_library)
             binding.unreadText.background =
                 MaterialShapeDrawable(makeShapeCorners(ogRadius, ogRadius)).apply {
                     this.fillColor =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
@@ -36,9 +36,9 @@ class SettingsBrowseController : SettingsController() {
                     titleRes = R.string.hide_in_library_items
                 }
                 switchPreference {
-                    bindTo(preferences.showDuplicatedInLibraryItems())
-                    titleRes = R.string.show_duplicated_in_library_items
-                    summaryRes = R.string.show_duplicated_in_library_items_summary
+                    bindTo(preferences.showDuplicateInLibraryItems())
+                    titleRes = R.string.show_duplicate_in_library_items
+                    summaryRes = R.string.show_duplicate_in_library_items_summary
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
@@ -35,6 +35,11 @@ class SettingsBrowseController : SettingsController() {
                     bindTo(preferences.hideInLibraryItems())
                     titleRes = R.string.hide_in_library_items
                 }
+                switchPreference {
+                    bindTo(preferences.showDuplicatedInLibraryItems())
+                    titleRes = R.string.show_duplicated_in_library_items
+                    summaryRes = R.string.show_duplicated_in_library_items_summary
+                }
             }
 
             preferenceCategory {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
@@ -85,12 +85,12 @@ class BrowseSourceGridHolder(
                 binding.card.strokeColor = ColorUtils.setAlphaComponent(color, if (manga.favorite) 87 else 255)
             }
 
-            if (prefs.showDuplicatedInLibraryItems().get()) {
+            if (!manga.favorite && prefs.showDuplicateInLibraryItems().get()) {
                 val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
 
-                if (duplicatedManga != null && !manga.favorite) {
+                if (duplicatedManga != null) {
                     binding.coverThumbnail.alpha = 0.34f
-                    binding.unreadDownloadBadge.root.setDuplicatedInLibrary(true)
+                    binding.unreadDownloadBadge.root.setDuplicateInLibrary(true)
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceGridHolder.kt
@@ -10,12 +10,16 @@ import coil.dispose
 import coil.request.ImageRequest
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.image.coil.CoverViewTarget
 import eu.kanade.tachiyomi.data.image.coil.MangaCoverFetcher
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.databinding.MangaGridItemBinding
 import eu.kanade.tachiyomi.ui.library.LibraryCategoryAdapter
 import eu.kanade.tachiyomi.util.view.setCards
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 /**
  * Class used to hold the displayed data of a manga in the library, like the cover or the title.
@@ -30,6 +34,8 @@ class BrowseSourceGridHolder(
     private val adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
     compact: Boolean,
     showOutline: Boolean,
+    val db: DatabaseHelper = Injekt.get(),
+    val prefs: PreferencesHelper = Injekt.get(),
 ) : BrowseSourceHolder(view, adapter) {
     private val binding = MangaGridItemBinding.bind(view)
 
@@ -77,6 +83,15 @@ class BrowseSourceGridHolder(
             binding.coverThumbnail.alpha = if (manga.favorite) 0.34f else 1.0f
             binding.card.strokeColorStateList?.defaultColor?.let { color ->
                 binding.card.strokeColor = ColorUtils.setAlphaComponent(color, if (manga.favorite) 87 else 255)
+            }
+
+            if (prefs.showDuplicatedInLibraryItems().get()) {
+                val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
+
+                if (duplicatedManga != null && !manga.favorite) {
+                    binding.coverThumbnail.alpha = 0.34f
+                    binding.unreadDownloadBadge.root.setDuplicatedInLibrary(true)
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceListHolder.kt
@@ -8,11 +8,15 @@ import coil.dispose
 import coil.request.ImageRequest
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.image.coil.CoverViewTarget
 import eu.kanade.tachiyomi.data.image.coil.MangaCoverFetcher
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.databinding.MangaListItemBinding
 import eu.kanade.tachiyomi.util.view.setCards
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 /**
  * Class used to hold the displayed data of a manga in the catalogue, like the cover or the title.
@@ -26,6 +30,8 @@ class BrowseSourceListHolder(
     private val view: View,
     adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
     showOutline: Boolean,
+    val db: DatabaseHelper = Injekt.get(),
+    val prefs: PreferencesHelper = Injekt.get(),
 ) : BrowseSourceHolder(view, adapter) {
     private val binding = MangaListItemBinding.bind(view)
 
@@ -62,6 +68,15 @@ class BrowseSourceListHolder(
             Coil.imageLoader(view.context).enqueue(request)
 
             binding.coverThumbnail.alpha = if (manga.favorite) 0.34f else 1.0f
+
+            if (prefs.showDuplicatedInLibraryItems().get()) {
+                val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
+
+                if (duplicatedManga != null && !manga.favorite) {
+                    binding.coverThumbnail.alpha = 0.34f
+                    binding.duplicatedInLibraryBadge.badge.isVisible = true
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceListHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceListHolder.kt
@@ -69,12 +69,12 @@ class BrowseSourceListHolder(
 
             binding.coverThumbnail.alpha = if (manga.favorite) 0.34f else 1.0f
 
-            if (prefs.showDuplicatedInLibraryItems().get()) {
+            if (!manga.favorite && prefs.showDuplicateInLibraryItems().get()) {
                 val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
 
-                if (duplicatedManga != null && !manga.favorite) {
+                if (duplicatedManga != null) {
                     binding.coverThumbnail.alpha = 0.34f
-                    binding.duplicatedInLibraryBadge.badge.isVisible = true
+                    binding.duplicateInLibraryBadge.duplicateBadge.isVisible = true
                 }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/globalsearch/GlobalSearchMangaHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/globalsearch/GlobalSearchMangaHolder.kt
@@ -71,11 +71,11 @@ class GlobalSearchMangaHolder(
         setImage(manga)
         binding.itemImage.alpha = if (manga.favorite) 0.34f else 1.0f
 
-        binding.duplicatedInLibraryButton.isVisible = false
-        if (!manga.favorite && prefs.showDuplicatedInLibraryItems().get()) {
+        binding.duplicateInLibraryButton.isVisible = false
+        if (!manga.favorite && prefs.showDuplicateInLibraryItems().get()) {
             val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
             if (duplicatedManga != null) {
-                binding.duplicatedInLibraryButton.isVisible = true
+                binding.duplicateInLibraryButton.isVisible = true
                 binding.itemImage.alpha = 0.34f
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/globalsearch/GlobalSearchMangaHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/globalsearch/GlobalSearchMangaHolder.kt
@@ -10,16 +10,22 @@ import coil.request.ImageRequest
 import com.google.android.material.animation.AnimationUtils.lerp
 import com.google.android.material.shape.CornerFamily
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.image.coil.CoverViewTarget
 import eu.kanade.tachiyomi.data.image.coil.MangaCoverFetcher
+import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.databinding.SourceGlobalSearchControllerCardItemBinding
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.util.system.isLTR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 
 class GlobalSearchMangaHolder(
     view: View,
     adapter: GlobalSearchCardAdapter,
+    val db: DatabaseHelper = Injekt.get(),
+    val prefs: PreferencesHelper = Injekt.get(),
 ) : BaseFlexibleViewHolder(view, adapter) {
     private val binding = SourceGlobalSearchControllerCardItemBinding.bind(view)
 
@@ -64,6 +70,15 @@ class GlobalSearchMangaHolder(
         binding.favoriteButton.isVisible = manga.favorite
         setImage(manga)
         binding.itemImage.alpha = if (manga.favorite) 0.34f else 1.0f
+
+        binding.duplicatedInLibraryButton.isVisible = false
+        if (!manga.favorite && prefs.showDuplicatedInLibraryItems().get()) {
+            val duplicatedManga = db.getDuplicateLibraryManga(manga).executeAsBlocking()
+            if (duplicatedManga != null) {
+                binding.duplicatedInLibraryButton.isVisible = true
+                binding.itemImage.alpha = 0.34f
+            }
+        }
     }
 
     var drawable: Drawable? = null

--- a/app/src/main/res/layout/duplicate_in_library_badge.xml
+++ b/app/src/main/res/layout/duplicate_in_library_badge.xml
@@ -2,7 +2,7 @@
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/badge"
+    android:id="@+id/duplicate_badge"
     android:layout_width="10dp"
     android:layout_height="10dp"
     app:cardCornerRadius="10dp"

--- a/app/src/main/res/layout/duplicated_in_library_badge.xml
+++ b/app/src/main/res/layout/duplicated_in_library_badge.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/badge"
+    android:layout_width="10dp"
+    android:layout_height="10dp"
+    app:cardCornerRadius="10dp"
+    app:cardElevation="4dp"
+    app:cardBackgroundColor="?attr/colorSecondary"
+    android:visibility="gone"
+    tools:visibility="visible"/>

--- a/app/src/main/res/layout/manga_list_item.xml
+++ b/app/src/main/res/layout/manga_list_item.xml
@@ -18,6 +18,16 @@
         android:layout_marginStart="2dp"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <include
+        layout="@layout/duplicated_in_library_badge"
+        android:id="@+id/duplicated_in_library_badge"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="2dp"
+        android:layout_marginStart="2dp"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/card"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/manga_list_item.xml
+++ b/app/src/main/res/layout/manga_list_item.xml
@@ -19,8 +19,8 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <include
-        layout="@layout/duplicated_in_library_badge"
-        android:id="@+id/duplicated_in_library_badge"
+        layout="@layout/duplicate_in_library_badge"
+        android:id="@+id/duplicate_in_library_badge"
         android:layout_width="16dp"
         android:layout_height="16dp"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/source_global_search_controller_card_item.xml
+++ b/app/src/main/res/layout/source_global_search_controller_card_item.xml
@@ -73,6 +73,36 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/duplicated_in_library_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="10dp"
+            app:cardBackgroundColor="?attr/colorSecondary"
+            app:cardElevation="2dp"
+            android:layout_marginTop="3dp"
+            android:layout_marginEnd="3dp"
+            android:layout_gravity="top|end"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="wrap_content"
+                android:gravity="center"
+                android:maxLines="1"
+                android:paddingStart="5dp"
+                android:paddingEnd="5dp"
+                android:textSize="13sp"
+                android:textColor="?attr/colorOnSecondary"
+                style="?textAppearanceCaption"
+                android:layout_height="wrap_content"
+                android:tint="@color/md_white_1000"
+                android:text="@string/duplicated_in_library"/>
+
+        </com.google.android.material.card.MaterialCardView>
+
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/title"
             style="?textAppearanceBodyMedium"

--- a/app/src/main/res/layout/source_global_search_controller_card_item.xml
+++ b/app/src/main/res/layout/source_global_search_controller_card_item.xml
@@ -74,7 +74,7 @@
         </com.google.android.material.card.MaterialCardView>
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/duplicated_in_library_button"
+            android:id="@+id/duplicate_in_library_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:cardCornerRadius="10dp"
@@ -99,7 +99,7 @@
                 style="?textAppearanceCaption"
                 android:layout_height="wrap_content"
                 android:tint="@color/md_white_1000"
-                android:text="@string/duplicated_in_library"/>
+                android:text="@string/duplicate_in_library"/>
 
         </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="popular">Popular</string>
     <string name="browse">Browse</string>
     <string name="in_library">In Library</string>
+    <string name="duplicated_in_library">Duplicated</string>
     <string name="search_extensions">Search extensions…</string>
     <string name="all_sources">All sources</string>
     <string name="sources">Sources</string>
@@ -959,6 +960,8 @@
     <string name="only_search_pinned_when">Only search pinned sources</string>
     <string name="sources_to_search">Sources to search</string>
     <string name="hide_in_library_items">Hide entries already in library</string>
+    <string name="show_duplicated_in_library_items">Show \"Duplicated\" badge</string>
+    <string name="show_duplicated_in_library_items_summary">Display a \"Duplicated\" badge for entries already in library from another extension. Note: Some duplicates may not be detected due to differences in names or URLs.</string>
     <string name="match_pinned_sources">Match pinned sources</string>
     <string name="match_enabled_sources">Match enabled sources</string>
     <string name="only_enable_pinned_for_migration">Only enable your pinned sources for

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,7 +326,7 @@
     <string name="popular">Popular</string>
     <string name="browse">Browse</string>
     <string name="in_library">In Library</string>
-    <string name="duplicated_in_library">Duplicated</string>
+    <string name="duplicate_in_library">Duplicate</string>
     <string name="search_extensions">Search extensions…</string>
     <string name="all_sources">All sources</string>
     <string name="sources">Sources</string>
@@ -960,8 +960,8 @@
     <string name="only_search_pinned_when">Only search pinned sources</string>
     <string name="sources_to_search">Sources to search</string>
     <string name="hide_in_library_items">Hide entries already in library</string>
-    <string name="show_duplicated_in_library_items">Show \"Duplicated\" badge</string>
-    <string name="show_duplicated_in_library_items_summary">Display a \"Duplicated\" badge for entries already in library from another extension. Note: Some duplicates may not be detected due to differences in names or URLs.</string>
+    <string name="show_duplicate_in_library_items">Show \"Duplicate\" badge</string>
+    <string name="show_duplicate_in_library_items_summary">Display a \"Duplicate\" badge for entries already in library from another extension. Note: Some duplicates may not be detected due to differences in names or URLs.</string>
     <string name="match_pinned_sources">Match pinned sources</string>
     <string name="match_enabled_sources">Match enabled sources</string>
     <string name="only_enable_pinned_for_migration">Only enable your pinned sources for


### PR DESCRIPTION
<p>Adds an optional "Duplicated" badge that appears on browse/search results when an entry already exists in your library under a different extension/source. This helps avoid accidentally adding the same manga twice from two different sources.</p>

<ul>
  <li>New setting under <strong>Settings → Browse</strong>: "Show 'Duplicated' badge"</li>
  <li>When enabled, entries with a library duplicate (added via another source) are dimmed and marked with a "Duplicated" badge in:
    <ul>
      <li>Browse source grid view</li>
      <li>Browse source list view</li>
      <li>Global search results</li>
    </ul>
  </li>
  <li>Off by default.</li>
</ul>

<p><em>Note: detection relies on matching title/URL, so some duplicates may not be caught if names or URLs differ between sources.</em></p>

<img width="364" height="538" alt="image" src="https://github.com/user-attachments/assets/d1f3510c-ccf6-4d02-9009-963a196bedac" />
<br>
<img width="346" height="538" alt="image" src="https://github.com/user-attachments/assets/4edb5b5e-a481-439b-af42-35c52826fc93" />
