### PR TITLE
Download Filtered Chapters Only

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -1376,7 +1376,7 @@ class LibraryPresenter(
         presenterScope.launch {
             withContext(Dispatchers.IO) {
                 mangaList.forEach { list ->
-                    val chapters = db.getChapters(list).executeAsBlocking().filter { !it.read }
+                    val chapters = chapterFilter.filterChapters(db.getChapters(list).executeAsBlocking(), list).filter { !it.read }
                     downloadManager.downloadChapters(list, chapters)
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -1468,8 +1468,8 @@ class MangaDetailsController :
                     rangeMode = RangeMode.Download
                     return
                 }
-                R.id.download_unread -> presenter.allChapters.filter { !it.read }
-                R.id.download_all -> presenter.allChapters
+                R.id.download_unread -> presenter.chapters.filter { !it.read }
+                R.id.download_all -> presenter.chapters
                 else -> emptyList()
             }
         if (chaptersToDownload.isNotEmpty()) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -284,7 +284,7 @@ class MangaDetailsPresenter(
     fun hasDownloads(): Boolean = allChapters.any { it.isDownloaded }
 
     fun getUnreadChaptersSorted() =
-        allChapters
+        chapters
             .filter { !it.read && it.status == Download.State.NOT_DOWNLOADED }
             .distinctBy { it.name }
             .sortedWith(chapterSort.sortComparator(true))


### PR DESCRIPTION
Closes #1896

Changes Download unread/Download all and Next/Next 5 to use the currently filtered chapter list (`chapters`) instead of the unfiltered list (`allChapters`).

This prevents chapters excluded by active chapter filters, including scanlator filters, from being selected by these actions.

Also applies chapter filtering to Download unread from the Library, so chapters excluded by a manga's chapter filters are not included when downloading from the Library.

### Testing

Tested with chapters from multiple scanlators by filtering out one scanlator and confirming that filtered chapters were no longer:

* selected by Next/Next 5
* included in Download unread/Download all
* included in Download unread from the Library
