### PR TITLE
Scanlator Backup and Restore

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
@@ -414,7 +414,8 @@ class BackupRestorer(
     ) {
         if (filteredScanlators.isEmpty()) return
 
-        val actualList = ChapterUtil.getScanlators(manga.filtered_scanlators) + filteredScanlators
+        val actualList = ChapterUtil.getScanlators(manga.filtered_scanlators) +
+            filteredScanlators.flatMap { ChapterUtil.getScanlators(it) }
         manga.filtered_scanlators = ChapterUtil.getScanlatorString(actualList.toSet())
         db.updateMangaFilteredScanlators(manga).executeAsBlocking()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupRestorer.kt
@@ -32,6 +32,7 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.sourcePreferences
 import eu.kanade.tachiyomi.ui.library.LibrarySort
 import eu.kanade.tachiyomi.util.BackupUtil
+import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.isActive
@@ -161,20 +162,40 @@ class BackupRestorer(
             backupManga.brokenHistory.map { BackupHistory(it.url, it.lastRead, it.readDuration) } + backupManga.history
         val tracks = backupManga.getTrackingImpl()
         val customManga = backupManga.getCustomMangaInfo()
+        val filteredScanlators = backupManga.excludedScanlators
 
         try {
             val dbManga = db.getManga(manga.url, manga.source).executeAsBlocking()
             if (dbManga == null) {
                 // Manga not in database
-                restoreExistingManga(manga, chapters, categories, history, tracks, backupCategories, customManga)
+                restoreExistingManga(
+                    manga,
+                    chapters,
+                    categories,
+                    history,
+                    tracks,
+                    backupCategories,
+                    filteredScanlators,
+                    customManga,
+                )
             } else {
                 // Manga in database
                 // Copy information from manga already in database
                 manga.id = dbManga.id
+                manga.filtered_scanlators = dbManga.filtered_scanlators
                 manga.copyFrom(dbManga)
                 db.insertManga(manga).executeAsBlocking()
                 // Fetch rest of manga information
-                restoreNewManga(manga, chapters, categories, history, tracks, backupCategories, customManga)
+                restoreNewManga(
+                    manga,
+                    chapters,
+                    categories,
+                    history,
+                    tracks,
+                    backupCategories,
+                    filteredScanlators,
+                    customManga,
+                )
             }
         } catch (e: Exception) {
             val sourceName = sourceMapping[manga.source] ?: manga.source.toString()
@@ -200,6 +221,7 @@ class BackupRestorer(
         history: List<BackupHistory>,
         tracks: List<Track>,
         backupCategories: List<BackupCategory>,
+        filteredScanlators: List<String>,
         customManga: CustomMangaManager.MangaJson?,
     ) {
         val fetchedManga =
@@ -210,7 +232,7 @@ class BackupRestorer(
         fetchedManga.id ?: return
 
         restoreChapters(fetchedManga, chapters)
-        restoreExtras(fetchedManga, categories, history, tracks, backupCategories, customManga)
+        restoreExtras(fetchedManga, categories, history, tracks, backupCategories, filteredScanlators, customManga)
     }
 
     private fun restoreNewManga(
@@ -220,10 +242,11 @@ class BackupRestorer(
         history: List<BackupHistory>,
         tracks: List<Track>,
         backupCategories: List<BackupCategory>,
+        filteredScanlators: List<String>,
         customManga: CustomMangaManager.MangaJson?,
     ) {
         restoreChapters(backupManga, chapters)
-        restoreExtras(backupManga, categories, history, tracks, backupCategories, customManga)
+        restoreExtras(backupManga, categories, history, tracks, backupCategories, filteredScanlators, customManga)
     }
 
     private fun restoreChapters(
@@ -262,11 +285,13 @@ class BackupRestorer(
         history: List<BackupHistory>,
         tracks: List<Track>,
         backupCategories: List<BackupCategory>,
+        filteredScanlators: List<String>,
         customManga: CustomMangaManager.MangaJson?,
     ) {
         restoreCategories(manga, categories, backupCategories)
         restoreHistoryForManga(history)
         restoreTrackForManga(manga, tracks)
+        restoreFilteredScanlatorsForManga(manga, filteredScanlators)
         customManga?.id = manga.id!!
         customManga?.let { customMangaManager.saveMangaInfo(it) }
     }
@@ -381,6 +406,17 @@ class BackupRestorer(
         if (trackToUpdate.isNotEmpty()) {
             db.insertTracks(trackToUpdate).executeAsBlocking()
         }
+    }
+
+    private fun restoreFilteredScanlatorsForManga(
+        manga: Manga,
+        filteredScanlators: List<String>,
+    ) {
+        if (filteredScanlators.isEmpty()) return
+
+        val actualList = ChapterUtil.getScanlators(manga.filtered_scanlators) + filteredScanlators
+        manga.filtered_scanlators = ChapterUtil.getScanlatorString(actualList.toSet())
+        db.updateMangaFilteredScanlators(manga).executeAsBlocking()
     }
 
     private fun restoreAppPreferences(preferences: List<BackupPreference>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.database.models.MangaImpl
 import eu.kanade.tachiyomi.data.database.models.TrackImpl
 import eu.kanade.tachiyomi.data.library.CustomMangaManager
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
@@ -41,6 +42,7 @@ data class BackupManga(
     @ProtoNumber(103) var viewer_flags: Int? = null,
     @ProtoNumber(104) var history: List<BackupHistory> = emptyList(),
     @ProtoNumber(105) var updateStrategy: UpdateStrategy = UpdateStrategy.ALWAYS_UPDATE,
+    @ProtoNumber(108) var excludedScanlators: List<String> = emptyList(),
     // SY specific values
     @ProtoNumber(602) var customStatus: Int = 0,
     // J2K specific values
@@ -127,6 +129,7 @@ data class BackupManga(
                 viewer_flags = manga.viewer_flags.takeIf { it != -1 } ?: 0,
                 chapterFlags = manga.chapter_flags,
                 updateStrategy = manga.update_strategy,
+                excludedScanlators = ChapterUtil.getScanlators(manga.filtered_scanlators),
                 memo = memoAdapter.encode(manga.memo),
             ).also { backupManga ->
                 customMangaManager?.getManga(manga)?.let {


### PR DESCRIPTION
## Summary

Implements the backup/restore part of #1886 for per-manga scanlator filters.

The changes are limited to the existing backup model and manga restore flow.

## What changed

- Added `excludedScanlators` to `BackupManga` using protobuf field `108`.
- When creating a backup, `manga.filtered_scanlators` is converted to a `List<String>` using `ChapterUtil.getScanlators()` and stored in the backup.
- During restore, the saved scanlator filters are passed through the existing manga restore flow.
- Existing scanlator filters are preserved when restoring over a manga already in the library.
- Filters from the backup are merged with filters already present locally, with duplicates removed.
- The merged filters are converted back using `ChapterUtil.getScanlatorString()` and persisted with the existing `updateMangaFilteredScanlators()` method.
- If a backup contains no scanlator filter data, existing filters are left unchanged.

## Why it was implemented this way

J2K already stores scanlator filters in `manga.filtered_scanlators`, so no database migration or new database field is required. This change only adds the existing value to the backup/restore process.

Protobuf field `108` is used for `excludedScanlators`, matching the field used by Mihon/TachiyomiSY/Yōkai rather than introducing a J2K-specific backup field.

When restoring over an existing manga, filters are merged rather than replaced.

For example:

**Existing filters:**
- Scanlator A

**Backup filters:**
- Scanlator B

**After restore:**
- Scanlator A
- Scanlator B

Older backups remain compatible because `excludedScanlators` defaults to an empty list when field `108` is absent.

The implementation is based on the existing scanlator-filter backup behavior in Yōkai/TachiyomiSY, adapted to J2K's `filtered_scanlators` storage and database APIs.

## Testing

- [x] Built and ran the modified app successfully.
- [x] Created a backup with a scanlator excluded.
- [x] Restored the backup and confirmed the excluded scanlator was restored correctly.
- [x] Confirmed the restored scanlator filter remains stored after restoration.
