### PR TITLE
Add Return to source site button in webview

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/webview/WebViewActivity.kt
@@ -11,6 +11,7 @@ import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
 import androidx.core.graphics.ColorUtils
+import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.network.NetworkHelper
@@ -29,6 +30,9 @@ open class WebViewActivity : BaseWebViewActivity() {
     private val sourceManager by injectLazy<SourceManager>()
     private val network by injectLazy<NetworkHelper>()
     private var bundle: Bundle? = null
+    private var originalHost: String? = null
+    private var lastSourceUrl: String? = null
+    private var webViewHeaders = emptyMap<String, String>()
 
     private var backPressedCallback: OnBackPressedCallback? = null
     private val backCallback = {
@@ -69,16 +73,17 @@ open class WebViewActivity : BaseWebViewActivity() {
         }
         if (bundle == null) {
             val url = intent.extras!!.getString(URL_KEY) ?: return
-            var headers = emptyMap<String, String>()
+            originalHost = normalizedHost(url)
+            lastSourceUrl = url
             (sourceManager.get(intent.extras!!.getLong(SOURCE_KEY)) as? HttpSource)?.let { source ->
                 try {
-                    headers = source.headers.toMultimap().mapValues { it.value.getOrNull(0) ?: "" }
+                    webViewHeaders = source.headers.toMultimap().mapValues { it.value.getOrNull(0) ?: "" }
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to build headers")
                 }
             }
 
-            binding.webview.setUserAgent(headers["user-agent"] ?: network.defaultUserAgent)
+            binding.webview.setUserAgent(webViewHeaders["user-agent"] ?: network.defaultUserAgent)
 
             binding.webview.webViewClient =
                 object : WebViewClientCompat() {
@@ -92,7 +97,7 @@ open class WebViewActivity : BaseWebViewActivity() {
                         }
 
                         // Continue with request, but with custom headers
-                        view.loadUrl(url, headers)
+                        view.loadUrl(url, webViewHeaders)
                         return true
                     }
 
@@ -112,6 +117,7 @@ open class WebViewActivity : BaseWebViewActivity() {
                         favicon: Bitmap?,
                     ) {
                         super.onPageStarted(view, url, favicon)
+                        updateLastSourceUrl(url)
                         binding.progressBar.isIndeterminate = true
                         binding.progressBar.isVisible = true
                         invalidateOptionsMenu()
@@ -131,13 +137,14 @@ open class WebViewActivity : BaseWebViewActivity() {
                         isReload: Boolean,
                     ) {
                         super.doUpdateVisitedHistory(view, url, isReload)
+                        updateLastSourceUrl(url)
                         if (!isReload) {
                             invalidateOptionsMenu()
                         }
                     }
                 }
 
-            binding.webview.loadUrl(url, headers)
+            binding.webview.loadUrl(url, webViewHeaders)
         }
     }
 
@@ -158,14 +165,39 @@ open class WebViewActivity : BaseWebViewActivity() {
         backPressedCallback?.isEnabled = binding.webview.canGoBack()
     }
 
+    private fun normalizedHost(url: String?): String? =
+        url
+            ?.toUri()
+            ?.host
+            ?.lowercase()
+            ?.removePrefix("www.")
+
+    private fun isOriginalHost(url: String?): Boolean =
+        originalHost != null && normalizedHost(url) == originalHost
+
+    private fun updateLastSourceUrl(url: String?) {
+        if (isOriginalHost(url)) {
+            lastSourceUrl = url
+        }
+    }
+
+    private fun returnToSource() {
+        lastSourceUrl?.let { binding.webview.loadUrl(it, webViewHeaders) }
+    }
+
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         val backItem = binding.toolbar.menu.findItem(R.id.action_web_back)
         val forwardItem = binding.toolbar.menu.findItem(R.id.action_web_forward)
+        val returnToSourceItem = binding.toolbar.menu.findItem(R.id.action_return_to_source)
         backItem?.isEnabled = binding.webview.canGoBack()
         forwardItem?.isEnabled = binding.webview.canGoForward()
         val hasHistory = binding.webview.canGoBack() || binding.webview.canGoForward()
         backItem?.isVisible = hasHistory
         forwardItem?.isVisible = hasHistory
+        returnToSourceItem?.isVisible =
+            lastSourceUrl != null &&
+                binding.webview.url != null &&
+                !isOriginalHost(binding.webview.url)
         val tintColor = getResourceColor(R.attr.actionBarTintColor)
         val translucentWhite = ColorUtils.setAlphaComponent(tintColor, 127)
         backItem.icon?.setTint(if (binding.webview.canGoBack()) tintColor else translucentWhite)
@@ -187,6 +219,7 @@ open class WebViewActivity : BaseWebViewActivity() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.action_web_back -> binding.webview.goBack()
+            R.id.action_return_to_source -> returnToSource()
             R.id.action_web_forward -> binding.webview.goForward()
             R.id.action_web_share -> shareWebpage()
             R.id.action_web_browser -> openInBrowser()

--- a/app/src/main/res/menu/webview.xml
+++ b/app/src/main/res/menu/webview.xml
@@ -8,6 +8,12 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/action_return_to_source"
+        android:icon="@drawable/ic_history_24dp"
+        android:title="@string/return_to_source"
+        app:showAsAction="always" />
+
+    <item
         android:id="@+id/action_open_in_app"
         android:icon="@drawable/ic_browse_24dp"
         android:title="@string/open_in_app"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1237,6 +1237,7 @@
     <string name="replace">Replace</string>
     <string name="reset">Reset</string>
     <string name="restore">Restore</string>
+    <string name="return_to_source">Return to source</string>
     <string name="resume">Resume</string>
     <string name="retry">Retry</string>
     <string name="right">Right</string>


### PR DESCRIPTION
# Add Return to Source action to WebView

## Summary

Adds a **Return to source** action to the WebView toolbar.

The WebView now remembers the domain it was originally opened on and keeps track of the most recent URL visited on that domain. If navigation later leaves the original domain, the **Return to source** action becomes available and can be used to jump directly back to the last remembered source URL.

For example:

```text
source.com/title
→ source.com/chapter
→ ad-redirect.com
→ another-ad.com

Return to source
→ source.com/chapter
```

## Why

The main use case is sources with **persistent redirect ads**.

These can sometimes send the WebView through multiple external pages, making the normal **Back** button inconvenient since the user may need to navigate backwards through several redirects before reaching the source again.

This can also be useful outside of ads. If a user intentionally follows an external link and ends up several pages deep on another site, **Return to source** provides a quick way to get back to where they last were on the original source.

Nothing is automatically blocked. External navigation continues to behave normally, and if the user intentionally leaves the source they can simply ignore the action.

## Implementation

The change is intentionally small and aims to use J2K's existing WebView navigation:

- Stores the original host when the WebView is opened.
- Tracks the latest URL visited on that host.
- Normalises the host for comparison.
- Shows **Return to source** when the current URL is outside the original host.
- Loads the remembered source URL using the source's existing request headers when pressed.
- Adds the corresponding WebView toolbar menu item and string resource.

No changes are made to popup handling, WebView history, source behaviour, or navigation itself.

## TachiyomiSY inspiration

The idea was inspired by seeing TachiyomiSY's handling of WebView popups, although this does **not use or port SY's implementation/code**. I only briefly looked at SY while considering the problem and implemented this separately using J2K's existing WebView structure.

SY's approach of handling popups through separate WebView windows may ultimately be the more complete solution, since it can prevent unwanted popup navigation from replacing the original page in the first place.

This takes a deliberately simpler approach instead:

> **Allow WebView navigation to behave normally, but remember where the user was on the source and provide a manual way back.**

This avoids introducing separate-window/popup management while still addressing the main annoyance, particularly persistent redirect ads, while also providing a useful general shortcut when navigating away from a source.

If you feel like implementing this, feel free to change anything you think would work better for J2K.