### PR TITLE
Add option to show badge showcasing latest chapter number

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/ChapterQueries.kt
@@ -45,6 +45,34 @@ interface ChapterQueries : DbProvider {
                     .build(),
             ).prepare()
 
+    fun getLatestChapterNumbers(mangaIds: List<Long>): Map<Long, Float> {
+        if (mangaIds.isEmpty()) return emptyMap()
+
+        val result = HashMap<Long, Float>()
+        mangaIds.distinct().chunked(500).forEach { ids ->
+            val cursor =
+                db
+                    .lowLevel()
+                    .rawQuery(
+                        RawQuery
+                            .builder()
+                            .query(
+                                "SELECT ${ChapterTable.COL_MANGA_ID}, MAX(${ChapterTable.COL_CHAPTER_NUMBER}) " +
+                                    "FROM ${ChapterTable.TABLE} " +
+                                    "WHERE ${ChapterTable.COL_MANGA_ID} IN (${ids.joinToString(",")}) " +
+                                    "GROUP BY ${ChapterTable.COL_MANGA_ID}",
+                            ).observesTables(ChapterTable.TABLE)
+                            .build(),
+                    )
+            cursor.use {
+                while (it.moveToNext()) {
+                    result[it.getLong(0)] = it.getFloat(1)
+                }
+            }
+        }
+        return result
+    }
+
     fun getRecentChapters(
         search: String = "",
         offset: Int,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -166,6 +166,8 @@ object PreferenceKeys {
 
     const val downloadBadge = "display_download_badge"
 
+    const val latestChapterBadge = "display_latest_chapter_badge"
+
     const val languageBadge = "display_language_badge"
 
     const val useBiometrics = "use_biometrics"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -314,6 +314,8 @@ class PreferencesHelper(
 
     fun downloadBadge() = flowPrefs.getBoolean(Keys.downloadBadge, false)
 
+    fun latestChapterBadge() = flowPrefs.getBoolean(Keys.latestChapterBadge, false)
+
     fun languageBadge() = flowPrefs.getBoolean(Keys.languageBadge, false)
 
     fun filterDownloaded() = flowPrefs.getInt(Keys.filterDownloaded, 0)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryBadge.kt
@@ -46,6 +46,7 @@ class LibraryBadge
             showTotalChapters: Boolean,
             lang: String?,
             changeShape: Boolean,
+            latestChapter: Int? = null,
         ) {
             // Update the unread count and its visibility.
 
@@ -71,6 +72,16 @@ class LibraryBadge
                     },
                 )
                 setBackgroundColor(unreadBadgeBackground)
+            }
+
+            val latestBadgeBackground = context.getResourceColor(R.attr.colorSecondaryContainer)
+            with(binding.latestText) {
+                isVisible = latestChapter != null
+                if (latestChapter != null) {
+                    text = latestChapter.toString()
+                    setTextColor(context.getResourceColor(R.attr.colorOnSecondaryContainer))
+                    setBackgroundColor(latestBadgeBackground)
+                }
             }
 
             // Update the download count or local status and its visibility.
@@ -104,6 +115,7 @@ class LibraryBadge
 
             binding.unreadAngle.isVisible = false
             binding.downloadAngle.isVisible = false
+            binding.latestAngle.isVisible = false
             val visibleChildren: List<View> =
                 (0 until binding.cardConstraint.childCount)
                     .mapNotNull {
@@ -118,7 +130,13 @@ class LibraryBadge
                     binding.unreadText.updateLayoutParams { width = (roundedRadius * 2).toInt() }
                     shapeAppearanceModel = shapeAppearanceModel.withCornerSize(roundedRadius)
                 } else {
-                    shapeAppearanceModel = makeShapeCorners(ogRadius, if (hasUnreadDot) roundedRadius else ogRadius, hasUnreadDot)
+                    val unreadDotIsLast = hasUnreadDot && visibleChildren.lastOrNull() == binding.unreadText
+                    shapeAppearanceModel =
+                        makeShapeCorners(
+                            ogRadius,
+                            if (unreadDotIsLast) roundedRadius else ogRadius,
+                            unreadDotIsLast,
+                        )
                     if (hasUnreadDot) {
                         binding.unreadText.updateLayoutParams { width = (roundedRadius * 1.25f).toInt() }
                     }
@@ -126,11 +144,7 @@ class LibraryBadge
                         val startRadius = if (index == 0) ogRadius else 0f
                         val endRadius =
                             if (index == visibleChildren.size - 1) {
-                                if (binding.unreadText.isVisible && unread == -1) {
-                                    roundedRadius
-                                } else {
-                                    ogRadius
-                                }
+                                if (view == binding.unreadText && hasUnreadDot) roundedRadius else ogRadius
                             } else {
                                 0f
                             }
@@ -138,6 +152,7 @@ class LibraryBadge
                             when (view) {
                                 binding.downloadText -> context.getResourceColor(R.attr.colorTertiary)
                                 binding.unreadText -> unreadBadgeBackground
+                                binding.latestText -> latestBadgeBackground
                                 else -> context.getResourceColor(R.attr.background)
                             }
                         if (view is ShapeableImageView) {
@@ -163,32 +178,39 @@ class LibraryBadge
                 }
             }
 
-            // Show the badge card if unread or downloads exists
+            // Show the badge card if any badge segment exists
             isVisible = visibleChildren.isNotEmpty()
 
-            // Show the angles divider if both unread and downloads exists
+            // Show an angled divider before each visible segment that follows another segment.
             binding.unreadAngle.isVisible =
                 binding.unreadText.isVisible &&
-                visibleChildren.size > 1
+                visibleChildren.indexOf(binding.unreadText) > 0
             binding.downloadAngle.isVisible =
                 binding.downloadText.isVisible &&
                 binding.langImage.isVisible
+            binding.latestAngle.isVisible =
+                binding.latestText.isVisible &&
+                visibleChildren.indexOf(binding.latestText) > 0
 
             binding.unreadAngle.setColorFilter(unreadBadgeBackground)
-            if (binding.unreadAngle.isVisible) {
-                binding.downloadText.updatePaddingRelative(end = 8.dpToPx)
-                binding.unreadText.updatePaddingRelative(start = 2.dpToPx)
-            } else {
-                binding.downloadText.updatePaddingRelative(end = 5.dpToPx)
-                binding.unreadText.updatePaddingRelative(start = 5.dpToPx)
-            }
+            binding.latestAngle.setColorFilter(latestBadgeBackground)
+
             binding.downloadText.updatePaddingRelative(
-                start =
-                    if (binding.downloadAngle.isVisible) {
-                        2.dpToPx
+                start = if (binding.downloadAngle.isVisible) 2.dpToPx else 5.dpToPx,
+                end =
+                    if (binding.unreadAngle.isVisible || (!binding.unreadText.isVisible && binding.latestAngle.isVisible)) {
+                        8.dpToPx
                     } else {
                         5.dpToPx
                     },
+            )
+            binding.unreadText.updatePaddingRelative(
+                start = if (binding.unreadAngle.isVisible) 2.dpToPx else 5.dpToPx,
+                end = if (binding.latestAngle.isVisible) 8.dpToPx else 5.dpToPx,
+            )
+            binding.latestText.updatePaddingRelative(
+                start = if (binding.latestAngle.isVisible) 2.dpToPx else 5.dpToPx,
+                end = 5.dpToPx,
             )
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryHolder.kt
@@ -9,6 +9,7 @@ import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.util.isLocal
 import eu.kanade.tachiyomi.util.system.getResourceColor
 import eu.kanade.tachiyomi.util.view.setCards
+import kotlin.math.floor
 
 /**
  * Generic class used to hold the displayed data of a manga in the library.
@@ -59,6 +60,9 @@ abstract class LibraryHolder(
             showTotal,
             item.sourceLanguage,
             this is LibraryGridHolder,
+            item.latestChapterNumber
+                .takeIf { it > 0f }
+                ?.let { floor(it).toInt() },
         )
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryItem.kt
@@ -38,6 +38,7 @@ class LibraryItem(
     IFilterable<String> {
     var downloadCount = -1
     var unreadType = 2
+    var latestChapterNumber = -1f
     var sourceLanguage: String? = null
     var filter = ""
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -256,6 +256,7 @@ class LibraryPresenter(
                 setDownloadCount(hiddenItems)
                 setUnreadBadge(hiddenItems)
                 setSourceLanguage(hiddenItems)
+                setLatestChapterNumber(library, hiddenItems)
                 allLibraryItems = library
                 hiddenLibraryItems = hiddenItems
                 var mangaMap = library
@@ -621,6 +622,33 @@ class LibraryPresenter(
 
         for (item in itemList) {
             item.downloadCount = downloadManager.getDownloadCount(item.manga)
+        }
+    }
+
+    private suspend fun setLatestChapterNumber(vararg itemLists: List<LibraryItem>) {
+        if (!preferences.latestChapterBadge().get()) {
+            itemLists.forEach { items ->
+                items.forEach { it.latestChapterNumber = -1f }
+            }
+            return
+        }
+
+        val mangaIds =
+            itemLists
+                .asSequence()
+                .flatten()
+                .mapNotNull { it.manga.id }
+                .distinct()
+                .toList()
+        val latestByManga =
+            withContext(Dispatchers.IO) {
+                db.getLatestChapterNumbers(mangaIds)
+            }
+
+        itemLists.forEach { items ->
+            items.forEach { item ->
+                item.latestChapterNumber = latestByManga[item.manga.id] ?: -1f
+            }
         }
     }
 
@@ -1169,6 +1197,14 @@ class LibraryPresenter(
     /** Requests the library to have language badges changed. */
     fun requestLanguageBadgesUpdate() {
         requestBadgeUpdate { setSourceLanguage(it) }
+    }
+
+    /** Requests the library to have latest chapter badges added/removed. */
+    fun requestLatestChapterBadgesUpdate() {
+        presenterScope.launch {
+            setLatestChapterNumber(allLibraryItems, hiddenLibraryItems, libraryItems)
+            sectionLibrary(libraryItems)
+        }
     }
 
     /** Requests the library to be sorted. */

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/display/LibraryBadgesView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/display/LibraryBadgesView.kt
@@ -22,6 +22,9 @@ class LibraryBadgesView
             binding.downloadBadge.bindToPreference(preferences.downloadBadge()) {
                 controller?.presenter?.requestDownloadBadgesUpdate()
             }
+            binding.latestChapterBadge.bindToPreference(preferences.latestChapterBadge()) {
+                controller?.presenter?.requestLatestChapterBadgesUpdate()
+            }
             binding.languageBadge.bindToPreference(preferences.languageBadge()) {
                 controller?.presenter?.requestLanguageBadgesUpdate()
             }

--- a/app/src/main/res/layout/library_badges_layout.xml
+++ b/app/src/main/res/layout/library_badges_layout.xml
@@ -63,6 +63,14 @@
             android:text="@string/download_badge" />
 
         <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/latest_chapter_badge"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
+            android:text="@string/latest_chapter_badge" />
+
+        <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/show_number_of_items"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/unread_download_badge.xml
+++ b/app/src/main/res/layout/unread_download_badge.xml
@@ -55,14 +55,14 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:barrierDirection="bottom"
-            app:constraint_referenced_ids="download_text,unread_text" />
+            app:constraint_referenced_ids="download_text,unread_text,latest_text" />
 
         <androidx.constraintlayout.widget.Barrier
             android:id="@+id/top_text_barrier"
             android:layout_width="0dp"
             android:layout_height="0dp"
             app:barrierDirection="top"
-            app:constraint_referenced_ids="download_text,unread_text" />
+            app:constraint_referenced_ids="download_text,unread_text,latest_text" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/download_text"
@@ -112,11 +112,44 @@
             android:visibility="gone"
             app:layout_constraintHeight_min="wrap"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/latest_text"
             app:layout_constraintStart_toEndOf="@id/download_text"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="20"
             tools:visibility="visible"
             tools:paddingStart="2dp"/>
+
+        <ImageView
+            android:id="@+id/latest_angle"
+            android:layout_width="10dp"
+            android:scaleType="fitXY"
+            android:layout_height="0dp"
+            android:src="@drawable/unread_angled_badge"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/latest_text"
+            app:layout_constraintEnd_toStartOf="@id/latest_text"
+            app:layout_constraintTop_toTopOf="@+id/latest_text"
+            tools:ignore="ContentDescription" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/latest_text"
+            style="?textAppearanceCaption"
+            android:layout_width="wrap_content"
+            android:layout_height="0dp"
+            android:background="?attr/colorSecondaryContainer"
+            android:gravity="center"
+            android:maxLines="1"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:textColor="?attr/colorOnSecondaryContainer"
+            android:textSize="13sp"
+            android:visibility="gone"
+            app:layout_constraintHeight_min="wrap"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/unread_text"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="127"
+            tools:visibility="visible" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </eu.kanade.tachiyomi.ui.library.LibraryBadge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -197,6 +197,7 @@
     <string name="cover_only_grid">Cover-only grid</string>
     <string name="compact_grid">Compact Grid</string>
     <string name="download_badge">Download badges</string>
+    <string name="latest_chapter_badge">Latest chapter number</string>
     <string name="language_badge">Language badges</string>
     <string name="hide_start_reading_button">Hide start reading button</string>
     <string name="badges">Badges</string>


### PR DESCRIPTION
This is something I mainly made for myself as a way to help clean up my library, and I’m not sure how useful others will find it, if at all, but I thought I’d share it anyway.

It adds an optional badge showing the highest known chapter number for each manga, with decimals rounded down for display (for example, 143.5 → 143).

useful for:

1. Comparing it against Total chapters to spot possible duplicate chapters or extra entries that may need filtering when the total chapter count and latest chapter number disagree substantially.
2. Seeing whether filtered chapters appear to include the latest known chapter, i.e. how far my chosen scanlator is from the highest available chapter number, and whether there may be a better scanlator to switch to (see images 3, 4 and 5 for an example). Admittedly, this isn’t the best way to determine that, but it does work to an extent without having to manually check each filtered scanlator’s chapter count.
3. Quickly seeing the latest main chapter number without .5/decimal chapters affecting the displayed value.

The badge can be enabled independently and shown alongside the existing download and unread/total badges.

When disabled, it shouldn’t add any extra chapter lookup work. When enabled, it uses a batched MAX(chapter_number) lookup rather than querying each manga individually, so the additional load should be fairly small.

One downside is that while the badge is enabled, Library refreshes during a bulk Library Update can cause the latest-number lookup to be repeated as updated entries trigger Library refreshes. This is only local database/CPU work and doesn’t add any extra source requests. It could be made more efficient by refreshing the latest-number values once at the end of a bulk Library Update instead of during intermediate Library refreshes.

I didn’t add that extra complexity for my own use since this is mostly just a convenience for cleaning up my library, the additional load has been minimal in my experience, and I don’t plan to keep it toggled on most of the time or really much at all, maybe never. For me it’s mainly a way of finding and correcting scanlator/filtering issues.

But if you think this is a worthwhile feature to have, feel free to change or simplify anything if there’s a better way to fit it into J2K.

(also unsure on colour choice)
<img width="1080" height="2340" alt="Screenshot_20260814_034856_TachiyomiJ2K" src="https://github.com/user-attachments/assets/40731774-38fa-4618-844b-6dbdb28a1c14" />
<img width="1080" height="2340" alt="Screenshot_20260814_025900_TachiyomiJ2K" src="https://github.com/user-attachments/assets/fdb266a8-73fb-4198-a205-4e91d03bbb97" />
<img width="1080" height="2340" alt="Screenshot_20260814_030005_TachiyomiJ2K" src="https://github.com/user-attachments/assets/60b33444-94c6-4cbe-8a5d-1a83065a38ba" />
<img width="1080" height="2340" alt="Screenshot_20260814_025950_TachiyomiJ2K" src="https://github.com/user-attachments/assets/bdec44c1-dcdf-48a0-b269-46692d3b786f" />
<img width="1080" height="2340" alt="Screenshot_20260814_025938_TachiyomiJ2K" src="https://github.com/user-attachments/assets/bb7393dd-000a-4139-89e7-2243bf5f88d2" />
<img width="1080" height="2340" alt="Screenshot_20260814_025927_TachiyomiJ2K" src="https://github.com/user-attachments/assets/a5e27cfd-1cc1-4038-98ac-95db1685c986" />
<img width="1080" height="2340" alt="Screenshot_20260814_025917_TachiyomiJ2K" src="https://github.com/user-attachments/assets/153348e2-6a18-4eb6-99f7-076ab5263843" />
