### PR TITLE
Bulk add and remove custom tags

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
@@ -55,6 +55,37 @@ class CustomMangaManager(
                 .toMutableMap()
     }
 
+    fun saveMangaInfo(mangas: List<MangaJson>) {
+        mangas.forEach { manga ->
+            val mangaId = manga.id ?: return@forEach
+            if (manga.title == null &&
+                manga.author == null &&
+                manga.artist == null &&
+                manga.description == null &&
+                manga.genre == null &&
+                (manga.status ?: -1) == -1
+            ) {
+                customMangaMap.remove(mangaId)
+            } else {
+                customMangaMap[mangaId] = manga.toManga()
+            }
+        }
+        saveCustomInfo()
+    }
+
+    fun getCustomInfo(manga: Manga): MangaJson? {
+        val custom = customMangaMap[manga.id] ?: return null
+        return MangaJson(
+            id = manga.id,
+            title = custom.title.takeUnless { it.isBlank() },
+            author = custom.author,
+            artist = custom.artist,
+            description = custom.description,
+            genre = custom.getGenres()?.toTypedArray(),
+            status = custom.status.takeUnless { it == -1 },
+        )
+    }
+
     fun saveMangaInfo(manga: MangaJson) {
         val mangaId = manga.id ?: return
         if (manga.title == null &&
@@ -76,6 +107,8 @@ class CustomMangaManager(
         if (jsonElements.isNotEmpty()) {
             editJson.delete()
             editJson.writeText(Json.encodeToString(MangaList(jsonElements)))
+        } else {
+            editJson.delete()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
 import android.view.ViewTreeObserver
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.ImageView
@@ -2411,7 +2412,9 @@ open class LibraryController(
         val migrationItem = menu.findItem(R.id.action_migrate)
         val shareItem = menu.findItem(R.id.action_share)
         val categoryItem = menu.findItem(R.id.action_move_to_category)
+        val customTagsItem = menu.findItem(R.id.action_custom_tags)
         categoryItem.isVisible = presenter.allCategories.size > 1
+        customTagsItem.isVisible = selectedMangas.any { !it.isLocal() }
         migrationItem.isVisible = selectedMangas.any { it.source != LocalSource.ID }
         shareItem.isVisible = migrationItem.isVisible
         if (count == 0) {
@@ -2482,6 +2485,8 @@ open class LibraryController(
                     }.setNegativeButton(android.R.string.cancel, null)
                     .show()
             }
+            R.id.action_add_custom_tag -> showAddCustomTagDialog()
+            R.id.action_remove_custom_tag -> showRemoveCustomTagDialog()
             R.id.action_migrate -> {
                 val skipPre = preferences.skipPreMigration().get()
                 PreMigrationController.navigateToMigration(
@@ -2494,6 +2499,82 @@ open class LibraryController(
             else -> return false
         }
         return true
+    }
+
+    private fun showAddCustomTagDialog() {
+        val mangas = selectedMangas.filterNot { it.isLocal() }
+        if (mangas.isEmpty()) return
+        val savedTags = presenter.getAllCustomTags()
+        if (savedTags.isEmpty()) {
+            showNewCustomTagDialog(mangas)
+            return
+        }
+        val options = savedTags + activity!!.getString(R.string.enter_new_tag)
+        activity!!
+            .materialAlertDialog()
+            .setTitle(R.string.add_custom_tag)
+            .setItems(options.toTypedArray()) { _, which ->
+                if (which == savedTags.size) {
+                    showNewCustomTagDialog(mangas)
+                } else {
+                    presenter.addCustomTag(mangas, savedTags[which])
+                    destroyActionModeIfNeeded()
+                }
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showNewCustomTagDialog(mangas: List<Manga>) {
+        val input =
+            EditText(activity).apply {
+                hint = activity!!.getString(R.string.custom_tag_hint)
+                isSingleLine = true
+                setPadding(24.dpToPx, 0, 24.dpToPx, 0)
+            }
+        val dialog =
+            activity!!
+                .materialAlertDialog()
+                .setTitle(R.string.add_custom_tag)
+                .setView(input)
+                .setPositiveButton(R.string.add_tag, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            val tag =
+                input.text
+                    ?.toString()
+                    ?.trim()
+                    .orEmpty()
+            if (tag.isNotBlank()) {
+                presenter.addCustomTag(mangas, tag)
+                dialog.dismiss()
+                destroyActionModeIfNeeded()
+            }
+        }
+        input.requestFocus()
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+    }
+
+    private fun showRemoveCustomTagDialog() {
+        val mangas = selectedMangas.filterNot { it.isLocal() }
+        if (mangas.isEmpty()) return
+        val tags = presenter.getCustomTags(mangas)
+        if (tags.isEmpty()) {
+            activity!!
+                .materialAlertDialog()
+                .setMessage(R.string.no_custom_tags_selected)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
+            return
+        }
+        activity!!
+            .materialAlertDialog()
+            .setTitle(R.string.remove_custom_tag)
+            .setItems(tags.toTypedArray()) { _, which ->
+                presenter.removeCustomTag(mangas, tags[which])
+                destroyActionModeIfNeeded()
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     private fun markReadStatus(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.library.CustomMangaManager
 import eu.kanade.tachiyomi.data.preference.DelayedLibrarySuggestionsJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.minusAssign
@@ -70,6 +71,7 @@ class LibraryPresenter(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val chapterFilter: ChapterFilter = Injekt.get(),
     private val trackManager: TrackManager = Injekt.get(),
+    private val customMangaManager: CustomMangaManager = Injekt.get(),
 ) : BaseCoroutinePresenter<LibraryController>() {
     private val context = preferences.context
     private val viewContext
@@ -1223,6 +1225,92 @@ class LibraryPresenter(
                 requestDownloadBadgesUpdate()
             }
         }
+    }
+
+    fun getCustomTags(mangas: List<Manga>): List<String> =
+        mangas
+            .asSequence()
+            .flatMap { manga -> customTagsForManga(manga).asSequence() }
+            .distinctBy { it.lowercase(Locale.ROOT) }
+            .sortedBy { it.lowercase(Locale.ROOT) }
+            .toList()
+
+    fun getAllCustomTags(): List<String> = getCustomTags(allLibraryItems.map { it.manga })
+
+    fun addCustomTag(
+        mangas: List<Manga>,
+        tag: String,
+    ) {
+        val cleanTag = tag.trim()
+        if (cleanTag.isBlank()) return
+        presenterScope.launchIO {
+            val updates =
+                mangas.distinctBy { it.id }.mapNotNull { manga ->
+                    val current = manga.getGenres().orEmpty()
+                    if (current.any { it.equals(cleanTag, ignoreCase = true) }) return@mapNotNull null
+                    customInfoWithGenres(manga, current + cleanTag)
+                }
+            if (updates.isNotEmpty()) {
+                customMangaManager.saveMangaInfo(updates)
+                withUIContext { updateManga() }
+            }
+        }
+    }
+
+    fun removeCustomTag(
+        mangas: List<Manga>,
+        tag: String,
+    ) {
+        presenterScope.launchIO {
+            val updates =
+                mangas.distinctBy { it.id }.mapNotNull { manga ->
+                    if (customTagsForManga(manga).none { it.equals(tag, ignoreCase = true) }) {
+                        return@mapNotNull null
+                    }
+                    val remaining = manga.getGenres().orEmpty().filterNot { it.equals(tag, ignoreCase = true) }
+                    customInfoWithGenres(manga, remaining)
+                }
+            if (updates.isNotEmpty()) {
+                customMangaManager.saveMangaInfo(updates)
+                withUIContext { updateManga() }
+            }
+        }
+    }
+
+    private fun customTagsForManga(manga: Manga): List<String> {
+        val customGenres =
+            customMangaManager
+                .getCustomInfo(manga)
+                ?.genre
+                ?.toList()
+                .orEmpty()
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        return customGenres.filter { custom ->
+            originalGenres.none { it.equals(custom, ignoreCase = true) }
+        }
+    }
+
+    private fun customInfoWithGenres(
+        manga: Manga,
+        genres: List<String>,
+    ): CustomMangaManager.MangaJson {
+        val existing = customMangaManager.getCustomInfo(manga)
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        val genreOverride =
+            genres
+                .takeUnless { current ->
+                    current.size == originalGenres.size &&
+                        current.zip(originalGenres).all { (a, b) -> a.equals(b, ignoreCase = true) }
+                }?.toTypedArray()
+        return CustomMangaManager.MangaJson(
+            id = manga.id,
+            title = existing?.title,
+            author = existing?.author,
+            artist = existing?.artist,
+            description = existing?.description,
+            genre = genreOverride,
+            status = existing?.status,
+        )
     }
 
     /** Called when Library Service updates a manga, update the item as well */

--- a/app/src/main/res/menu/library_selection.xml
+++ b/app/src/main/res/menu/library_selection.xml
@@ -22,6 +22,20 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/action_custom_tags"
+        android:title="@string/custom_tags"
+        app:showAsAction="never">
+        <menu>
+            <item
+                android:id="@+id/action_add_custom_tag"
+                android:title="@string/add_custom_tag" />
+            <item
+                android:id="@+id/action_remove_custom_tag"
+                android:title="@string/remove_custom_tag" />
+        </menu>
+    </item>
+
+    <item
         android:id="@+id/action_download_unread"
         android:title="@string/download_unread"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,12 @@
     <string name="sort_by_chapter_number">Sort by chapter number</string>
     <string name="newest_first">Newest to oldest</string>
     <string name="oldest_first">Oldest to newest</string>
+    <string name="custom_tags">Custom tags</string>
+    <string name="add_custom_tag">Add custom tag</string>
+    <string name="remove_custom_tag">Remove custom tag</string>
+    <string name="enter_new_tag">Enter new tag…</string>
+    <string name="custom_tag_hint">Custom tag</string>
+    <string name="no_custom_tags_selected">The selected manga have no custom tags to remove</string>
     <string name="add_tag">Add tag</string>
     <string name="clear_tags">Clear tags</string>
     <string name="reset_tags">Reset tags</string>


### PR DESCRIPTION
## Summary

Adds a **Custom tags** action when selecting manga in the Library, allowing a tag to be added to multiple entries at once or an existing custom addition to be removed in bulk.

This builds on J2K's existing custom manga info/tag functionality.

## Why

J2K already allows tags to be added to individual manga through **Edit manga info**, alongside the entry's existing genres/tags. This adds a way to apply the same custom tag to multiple Library entries without having to edit each manga individually.

For example, I might want to select a group of manga and add:

> **Favourite**

to all of them at once.

Other examples could include `Good TL`, `Re-read`, `Official`, or any other personal label.

I thought this could also work particularly well with J2K's newer Library search functionality. Custom tags can provide an additional way to identify and search for groups of entries without having to create or reorganise Library categories.

## Adding tags

After selecting one or more manga:

**Custom tags → Add custom tag**

Existing tag values are available for quick selection, or a new tag can be entered manually.

The selected tag is added to each selected manga while preserving its existing genres/tags and other custom manga information.

If an entry already contains the selected tag, it isn't added again.

## Removing tags

**Custom tags → Remove custom tag**

Removal is deliberately more restricted.

J2K's existing manga info can contain both the original genres/tags supplied by the source and tags subsequently added through custom manga info. The bulk removal action compares the custom genre/tag state against the entry's original source genres and only offers tags that can be identified as custom additions.

This means original source-provided genres/tags cannot be bulk removed through this action.

Only a single custom tag can be selected for removal at a time. It is removed from any of the selected entries containing that custom addition, while their other tags and custom manga information are left unchanged.

## Implementation

The implementation reuses J2K's existing `CustomMangaManager` and custom manga info rather than adding a new database or metadata format.

It:

- Adds **Custom tags → Add custom tag / Remove custom tag** to Library multi-selection.
- Uses existing tag values for quick selection when adding, while still allowing a new tag to be entered manually.
- Adds the selected tag without replacing an entry's existing genres/tags.
- Avoids adding duplicate tags, including case-insensitive duplicates.
- Limits bulk removal to tags identifiable as custom additions rather than original source genres.
- Preserves existing custom title, author, artist, description and status information when modifying tags.
- Removes the custom genre override if removing a tag returns the genre/tag list to its original source state.
- Updates the selected entries in memory first and writes the custom info file once for the bulk operation rather than separately for every selected manga.

No new tag database or separate tag-storage system is introduced; the feature operates through J2K's existing custom manga info. Existing tags shown in video below were all custom added tags I added a while back for a different test.



## Testing

I've tested the main combinations I could think of, including:

- Bulk adding a new custom tag across multiple selected manga.
- Bulk removing a custom tag from multiple selected manga.
- Manually adding a tag through J2K's existing **Edit manga info** and confirming that the bulk removal action recognises and can remove it.
- Adding tags to different manga with different existing genres/tags and custom information, then removing them again without affecting the other metadata.
- Adding and removing tags across multiple entries repeatedly without issues.
- Confirming original/source-provided tags aren't offered as removable custom additions.
- Creating a backup containing the modified entries and restoring it successfully, with the existing backup/restore behaviour continuing to work.

Everything I've tested so far has worked as expected.

https://github.com/user-attachments/assets/2ba5c2c7-d823-417f-8eaa-19d46f108689

