### PR TITLE
Group by custom tag- Based off of #1903

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
@@ -55,6 +55,37 @@ class CustomMangaManager(
                 .toMutableMap()
     }
 
+    fun saveMangaInfo(mangas: List<MangaJson>) {
+        mangas.forEach { manga ->
+            val mangaId = manga.id ?: return@forEach
+            if (manga.title == null &&
+                manga.author == null &&
+                manga.artist == null &&
+                manga.description == null &&
+                manga.genre == null &&
+                (manga.status ?: -1) == -1
+            ) {
+                customMangaMap.remove(mangaId)
+            } else {
+                customMangaMap[mangaId] = manga.toManga()
+            }
+        }
+        saveCustomInfo()
+    }
+
+    fun getCustomInfo(manga: Manga): MangaJson? {
+        val custom = customMangaMap[manga.id] ?: return null
+        return MangaJson(
+            id = manga.id,
+            title = custom.title.takeUnless { it.isBlank() },
+            author = custom.author,
+            artist = custom.artist,
+            description = custom.description,
+            genre = custom.getGenres()?.toTypedArray(),
+            status = custom.status.takeUnless { it == -1 },
+        )
+    }
+
     fun saveMangaInfo(manga: MangaJson) {
         val mangaId = manga.id ?: return
         if (manga.title == null &&
@@ -76,6 +107,8 @@ class CustomMangaManager(
         if (jsonElements.isNotEmpty()) {
             editJson.delete()
             editJson.writeText(Json.encodeToString(MangaList(jsonElements)))
+        } else {
+            editJson.delete()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -82,6 +82,7 @@ import eu.kanade.tachiyomi.ui.base.controller.BaseCoroutineController
 import eu.kanade.tachiyomi.ui.category.CategoryController
 import eu.kanade.tachiyomi.ui.category.ManageCategoryDialog
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_AUTHOR
+import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_CUSTOM_TAG
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_DEFAULT
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_LANGUAGE
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_SOURCE
@@ -592,7 +593,7 @@ open class LibraryController(
     }
 
     internal fun showGroupOptions() {
-        val groupItems = mutableListOf(BY_DEFAULT, BY_TAG, BY_SOURCE, BY_STATUS, BY_AUTHOR)
+        val groupItems = mutableListOf(BY_DEFAULT, BY_TAG, BY_CUSTOM_TAG, BY_SOURCE, BY_STATUS, BY_AUTHOR)
         if (presenter.isLoggedIntoTracking) {
             groupItems.add(BY_TRACK_STATUS)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
 import android.view.ViewTreeObserver
+import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.ImageView
@@ -2411,7 +2412,9 @@ open class LibraryController(
         val migrationItem = menu.findItem(R.id.action_migrate)
         val shareItem = menu.findItem(R.id.action_share)
         val categoryItem = menu.findItem(R.id.action_move_to_category)
+        val customTagsItem = menu.findItem(R.id.action_custom_tags)
         categoryItem.isVisible = presenter.allCategories.size > 1
+        customTagsItem.isVisible = selectedMangas.any { !it.isLocal() }
         migrationItem.isVisible = selectedMangas.any { it.source != LocalSource.ID }
         shareItem.isVisible = migrationItem.isVisible
         if (count == 0) {
@@ -2482,6 +2485,8 @@ open class LibraryController(
                     }.setNegativeButton(android.R.string.cancel, null)
                     .show()
             }
+            R.id.action_add_custom_tag -> showAddCustomTagDialog()
+            R.id.action_remove_custom_tag -> showRemoveCustomTagDialog()
             R.id.action_migrate -> {
                 val skipPre = preferences.skipPreMigration().get()
                 PreMigrationController.navigateToMigration(
@@ -2494,6 +2499,82 @@ open class LibraryController(
             else -> return false
         }
         return true
+    }
+
+    private fun showAddCustomTagDialog() {
+        val mangas = selectedMangas.filterNot { it.isLocal() }
+        if (mangas.isEmpty()) return
+        val savedTags = presenter.getAllCustomTags()
+        if (savedTags.isEmpty()) {
+            showNewCustomTagDialog(mangas)
+            return
+        }
+        val options = savedTags + activity!!.getString(R.string.enter_new_tag)
+        activity!!
+            .materialAlertDialog()
+            .setTitle(R.string.add_custom_tag)
+            .setItems(options.toTypedArray()) { _, which ->
+                if (which == savedTags.size) {
+                    showNewCustomTagDialog(mangas)
+                } else {
+                    presenter.addCustomTag(mangas, savedTags[which])
+                    destroyActionModeIfNeeded()
+                }
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showNewCustomTagDialog(mangas: List<Manga>) {
+        val input =
+            EditText(activity).apply {
+                hint = activity!!.getString(R.string.custom_tag_hint)
+                isSingleLine = true
+                setPadding(24.dpToPx, 0, 24.dpToPx, 0)
+            }
+        val dialog =
+            activity!!
+                .materialAlertDialog()
+                .setTitle(R.string.add_custom_tag)
+                .setView(input)
+                .setPositiveButton(R.string.add_tag, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+            val tag =
+                input.text
+                    ?.toString()
+                    ?.trim()
+                    .orEmpty()
+            if (tag.isNotBlank()) {
+                presenter.addCustomTag(mangas, tag)
+                dialog.dismiss()
+                destroyActionModeIfNeeded()
+            }
+        }
+        input.requestFocus()
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+    }
+
+    private fun showRemoveCustomTagDialog() {
+        val mangas = selectedMangas.filterNot { it.isLocal() }
+        if (mangas.isEmpty()) return
+        val tags = presenter.getCustomTags(mangas)
+        if (tags.isEmpty()) {
+            activity!!
+                .materialAlertDialog()
+                .setMessage(R.string.no_custom_tags_selected)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
+            return
+        }
+        activity!!
+            .materialAlertDialog()
+            .setTitle(R.string.remove_custom_tag)
+            .setItems(tags.toTypedArray()) { _, which ->
+                presenter.removeCustomTag(mangas, tags[which])
+                destroyActionModeIfNeeded()
+            }.setNegativeButton(android.R.string.cancel, null)
+            .show()
     }
 
     private fun markReadStatus(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGroup.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGroup.kt
@@ -10,6 +10,7 @@ object LibraryGroup {
     const val BY_TRACK_STATUS = 4
     const val BY_AUTHOR = 6
     const val BY_LANGUAGE = 7
+    const val BY_CUSTOM_TAG = 8
     const val UNGROUPED = 5
 
     fun groupTypeStringRes(
@@ -19,6 +20,7 @@ object LibraryGroup {
         when (type) {
             BY_STATUS -> R.string.status
             BY_TAG -> R.string.tag
+            BY_CUSTOM_TAG -> R.string.custom_tags
             BY_SOURCE -> R.string.sources
             BY_TRACK_STATUS -> R.string.tracking_status
             BY_AUTHOR -> R.string.author
@@ -31,6 +33,7 @@ object LibraryGroup {
         when (type) {
             BY_STATUS -> R.drawable.ic_progress_clock_24dp
             BY_TAG -> R.drawable.ic_style_24dp
+            BY_CUSTOM_TAG -> R.drawable.ic_label_outline_24dp
             BY_TRACK_STATUS -> R.drawable.ic_sync_24dp
             BY_SOURCE -> R.drawable.ic_browse_24dp
             BY_AUTHOR -> R.drawable.ic_author_24dp

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -23,6 +23,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.base.presenter.BaseCoroutinePresenter
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_AUTHOR
+import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_CUSTOM_TAG
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_DEFAULT
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_LANGUAGE
 import eu.kanade.tachiyomi.ui.library.LibraryGroup.BY_SOURCE
@@ -963,6 +964,16 @@ class LibraryPresenter(
                                 }
                             tags.map {
                                 LibraryItem(manga, makeOrGetHeader(it), viewContext)
+                            }
+                        }
+                        BY_CUSTOM_TAG -> {
+                            val tags =
+                                customTagsForManga(manga).ifEmpty {
+                                    listOf(context.getString(R.string.untagged))
+                                }
+                            tags.map { tag ->
+                                val existingTag = tagItems.keys.find { it.equals(tag, ignoreCase = true) }
+                                LibraryItem(manga, makeOrGetHeader(existingTag ?: tag), viewContext)
                             }
                         }
                         BY_TRACK_STATUS -> {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.library.CustomMangaManager
 import eu.kanade.tachiyomi.data.preference.DelayedLibrarySuggestionsJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.minusAssign
@@ -70,6 +71,7 @@ class LibraryPresenter(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val chapterFilter: ChapterFilter = Injekt.get(),
     private val trackManager: TrackManager = Injekt.get(),
+    private val customMangaManager: CustomMangaManager = Injekt.get(),
 ) : BaseCoroutinePresenter<LibraryController>() {
     private val context = preferences.context
     private val viewContext
@@ -1223,6 +1225,92 @@ class LibraryPresenter(
                 requestDownloadBadgesUpdate()
             }
         }
+    }
+
+    fun getCustomTags(mangas: List<Manga>): List<String> =
+        mangas
+            .asSequence()
+            .flatMap { manga -> customTagsForManga(manga).asSequence() }
+            .distinctBy { it.lowercase(Locale.ROOT) }
+            .sortedBy { it.lowercase(Locale.ROOT) }
+            .toList()
+
+    fun getAllCustomTags(): List<String> = getCustomTags(allLibraryItems.map { it.manga })
+
+    fun addCustomTag(
+        mangas: List<Manga>,
+        tag: String,
+    ) {
+        val cleanTag = tag.trim()
+        if (cleanTag.isBlank()) return
+        presenterScope.launchIO {
+            val updates =
+                mangas.distinctBy { it.id }.mapNotNull { manga ->
+                    val current = manga.getGenres().orEmpty()
+                    if (current.any { it.equals(cleanTag, ignoreCase = true) }) return@mapNotNull null
+                    customInfoWithGenres(manga, current + cleanTag)
+                }
+            if (updates.isNotEmpty()) {
+                customMangaManager.saveMangaInfo(updates)
+                withUIContext { updateManga() }
+            }
+        }
+    }
+
+    fun removeCustomTag(
+        mangas: List<Manga>,
+        tag: String,
+    ) {
+        presenterScope.launchIO {
+            val updates =
+                mangas.distinctBy { it.id }.mapNotNull { manga ->
+                    if (customTagsForManga(manga).none { it.equals(tag, ignoreCase = true) }) {
+                        return@mapNotNull null
+                    }
+                    val remaining = manga.getGenres().orEmpty().filterNot { it.equals(tag, ignoreCase = true) }
+                    customInfoWithGenres(manga, remaining)
+                }
+            if (updates.isNotEmpty()) {
+                customMangaManager.saveMangaInfo(updates)
+                withUIContext { updateManga() }
+            }
+        }
+    }
+
+    private fun customTagsForManga(manga: Manga): List<String> {
+        val customGenres =
+            customMangaManager
+                .getCustomInfo(manga)
+                ?.genre
+                ?.toList()
+                .orEmpty()
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        return customGenres.filter { custom ->
+            originalGenres.none { it.equals(custom, ignoreCase = true) }
+        }
+    }
+
+    private fun customInfoWithGenres(
+        manga: Manga,
+        genres: List<String>,
+    ): CustomMangaManager.MangaJson {
+        val existing = customMangaManager.getCustomInfo(manga)
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        val genreOverride =
+            genres
+                .takeUnless { current ->
+                    current.size == originalGenres.size &&
+                        current.zip(originalGenres).all { (a, b) -> a.equals(b, ignoreCase = true) }
+                }?.toTypedArray()
+        return CustomMangaManager.MangaJson(
+            id = manga.id,
+            title = existing?.title,
+            author = existing?.author,
+            artist = existing?.artist,
+            description = existing?.description,
+            genre = genreOverride,
+            status = existing?.status,
+        )
     }
 
     /** Called when Library Service updates a manga, update the item as well */

--- a/app/src/main/res/menu/library_selection.xml
+++ b/app/src/main/res/menu/library_selection.xml
@@ -22,6 +22,20 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/action_custom_tags"
+        android:title="@string/custom_tags"
+        app:showAsAction="never">
+        <menu>
+            <item
+                android:id="@+id/action_add_custom_tag"
+                android:title="@string/add_custom_tag" />
+            <item
+                android:id="@+id/action_remove_custom_tag"
+                android:title="@string/remove_custom_tag" />
+        </menu>
+    </item>
+
+    <item
         android:id="@+id/action_download_unread"
         android:title="@string/download_unread"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="group_library_by">Group library by…</string>
     <string name="tracking_status">Tracking status</string>
     <string name="ungrouped">Ungrouped</string>
+    <string name="untagged">Untagged</string>
 
     <!-- Library Sort -->
     <string name="sort_by">Sort by</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,12 @@
     <string name="sort_by_chapter_number">Sort by chapter number</string>
     <string name="newest_first">Newest to oldest</string>
     <string name="oldest_first">Oldest to newest</string>
+    <string name="custom_tags">Custom tags</string>
+    <string name="add_custom_tag">Add custom tag</string>
+    <string name="remove_custom_tag">Remove custom tag</string>
+    <string name="enter_new_tag">Enter new tag…</string>
+    <string name="custom_tag_hint">Custom tag</string>
+    <string name="no_custom_tags_selected">The selected manga have no custom tags to remove</string>
     <string name="add_tag">Add tag</string>
     <string name="clear_tags">Clear tags</string>
     <string name="reset_tags">Reset tags</string>


### PR DESCRIPTION
## Summary

Adds a **Custom tags** option to Library grouping.

This builds on the bulk custom tag functionality from #1903  and groups manga using the custom tag additions already stored through J2K's existing custom manga info.

A manga with multiple custom tags appears in each relevant group.

For example:

- Manga A: `Favourite`, `Re-read`
- Manga B: `Favourite`
- Manga C: `Good TL`

Would appear as:

**Favourite**
- Manga A
- Manga B

**Good TL**
- Manga C

**Re-read**
- Manga A

Manga without any custom-added tags appear under **Untagged**.

## Behaviour

- Only tags identified as custom additions are used for grouping.
- Original source-provided genres/tags do not create Custom tag groups.
- Manga with multiple custom tags intentionally appear in multiple groups.
- Existing Library sorting continues to apply within each group.
- No new tag storage, database changes, or source requests are introduced.
- The grouping reuses the custom tag detection introduced by the bulk custom tag changes.

## Why

This gives custom tags a bit more utility beyond search and bulk assignment.

For example, entries tagged as `Favourite`, `Re-read`, `Good TL`, or other personal labels can be viewed together without needing to reorganise the user's normal Library categories.

Can also be used to quickly see which entries have custom tags to remove them quickly

## Testing

I've tested:

- Grouping manga with a single custom tag.
- Grouping manga with multiple custom tags and confirming they appear in each applicable group.
- Manga with no custom additions appearing under **Untagged**.
- Source-provided genres/tags not appearing as Custom tag groups.
- Adding a custom tag while grouped by Custom tags and confirming the manga appears in the new group.
- Removing a custom tag and confirming the manga is removed from that group without affecting its other groups.
- Existing Library sorting within the generated groups.
- Switching between Custom tags and the existing Library grouping modes without issues.

Everything I've tested so far has worked as expected.

## Dependency

This PR depends on #1903 , which adds the bulk custom tag handling and custom-tag detection used here.

If you think this would be useful, feel free to change or simplify anything to better fit J2K's Library grouping behaviour.