### PR TITLE
Add Expand or hide source entry description option. Fixes #1902

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -146,6 +146,8 @@ object PreferenceKeys {
 
     const val onlySearchPinned = "only_search_pinned"
 
+    const val expandSourceMangaDescription = "expand_source_manga_description"
+
     const val downloadNew = "download_new"
 
     const val libraryLayout = "pref_display_library_layout"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferencesHelper.kt
@@ -491,6 +491,8 @@ class PreferencesHelper(
 
     fun showDuplicateInLibraryItems() = flowPrefs.getBoolean("browse_show_duplicate_in_library_items", false)
 
+    fun expandSourceMangaDescription() = flowPrefs.getBoolean(Keys.expandSourceMangaDescription, false)
+
     // Tutorial preferences
     fun shownFilterTutorial() = flowPrefs.getBoolean("shown_filter_tutorial", false)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -105,7 +105,12 @@ class MangaDetailsPresenter(
     var allHistory: List<History> = emptyList()
         private set
 
-    val headerItem by lazy { MangaHeaderItem(manga, view?.fromCatalogue == true) }
+    val headerItem by lazy {
+        MangaHeaderItem(
+            manga,
+            view?.fromCatalogue == true && preferences.expandSourceMangaDescription().get(),
+        )
+    }
     var tabletChapterHeaderItem: MangaHeaderItem? = null
     var allChapterScanlators: Set<String> = emptySet()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/SettingsBrowseController.kt
@@ -40,6 +40,11 @@ class SettingsBrowseController : SettingsController() {
                     titleRes = R.string.show_duplicate_in_library_items
                     summaryRes = R.string.show_duplicate_in_library_items_summary
                 }
+                switchPreference {
+                    bindTo(preferences.expandSourceMangaDescription())
+                    titleRes = R.string.expand_source_manga_description
+                    summaryRes = R.string.expand_source_manga_description_summary
+                }
             }
 
             preferenceCategory {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -962,6 +962,8 @@
     <string name="hide_in_library_items">Hide entries already in library</string>
     <string name="show_duplicate_in_library_items">Show \"Duplicate\" badge</string>
     <string name="show_duplicate_in_library_items_summary">Display a \"Duplicate\" badge for entries already in library from another extension. Note: Some duplicates may not be detected due to differences in names or URLs.</string>
+    <string name="expand_source_manga_description">Expand manga descriptions from sources</string>
+    <string name="expand_source_manga_description_summary">Automatically expand the description when opening manga from a source</string>
     <string name="match_pinned_sources">Match pinned sources</string>
     <string name="match_enabled_sources">Match enabled sources</string>
     <string name="only_enable_pinned_for_migration">Only enable your pinned sources for


### PR DESCRIPTION
## Summary

Fixes the inconsistency where manga descriptions opened from **Browse / Sources** start expanded, while the same manga opened from the **Library** starts collapsed.

The default behaviour is now consistent:

- Opening from Library → description collapsed
- Opening from Browse / Source → description collapsed

A new Browse setting has also been added for users who prefer the previous behaviour:

**Expand manga descriptions from sources**

When enabled, manga opened from a source will continue to start with the description expanded.

## Why

This addresses the reported issue where opening manga from a source results in the description accordion being fully expanded by default, increasing the amount of scrolling needed to reach the chapter list.

The existing behaviour came from `fromCatalogue` being passed directly as the initial expanded state of the manga header.

This change separates those two concepts:

- `fromCatalogue` continues to be used for the existing source-related behaviour elsewhere in Manga Details.
- The description expansion state is now controlled independently by the new preference.

## Behaviour

### Default / setting disabled

- Library → collapsed
- Browse / Source → collapsed

### Setting enabled

- Library → collapsed
- Browse / Source → expanded

The setting only affects the initial state when opening manga from a source. The description can still be manually expanded or collapsed as normal.

## Implementation

- Adds a new `expand_source_manga_description` preference, defaulting to `false`.
- Adds **Expand manga descriptions from sources** to Browse settings.
- Changes the manga header's initial expanded state to require both:
  - the manga being opened from a source, and
  - the new preference being enabled.
- Leaves the existing `fromCatalogue` behaviour elsewhere unchanged.


## Testing

Tested:

- Opening a Library manga with the setting disabled.
- Opening the same manga from its source with the setting disabled.
- Opening a non-library manga from a source with the setting disabled.
- Enabling the setting and confirming source-opened manga start expanded.
- Confirming Library-opened manga remain collapsed with the setting enabled.
- Manually expanding/collapsing the description after opening.

Everything tested so far works as expected.

Fixes #1902 