### PR TITLE
Add support for saving search queries and filters in Browse Source

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DatabaseHelper.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DatabaseHelper.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.data.database.mappers.ChapterTypeMapping
 import eu.kanade.tachiyomi.data.database.mappers.HistoryTypeMapping
 import eu.kanade.tachiyomi.data.database.mappers.MangaCategoryTypeMapping
 import eu.kanade.tachiyomi.data.database.mappers.MangaTypeMapping
+import eu.kanade.tachiyomi.data.database.mappers.SavedSearchTypeMapping
 import eu.kanade.tachiyomi.data.database.mappers.SearchMetadataTypeMapping
 import eu.kanade.tachiyomi.data.database.mappers.TrackTypeMapping
 import eu.kanade.tachiyomi.data.database.models.Category
@@ -15,6 +16,7 @@ import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.History
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
 import eu.kanade.tachiyomi.data.database.models.SearchMetadata
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.database.queries.CategoryQueries
@@ -22,6 +24,7 @@ import eu.kanade.tachiyomi.data.database.queries.ChapterQueries
 import eu.kanade.tachiyomi.data.database.queries.HistoryQueries
 import eu.kanade.tachiyomi.data.database.queries.MangaCategoryQueries
 import eu.kanade.tachiyomi.data.database.queries.MangaQueries
+import eu.kanade.tachiyomi.data.database.queries.SavedSearchQueries
 import eu.kanade.tachiyomi.data.database.queries.SearchMetadataQueries
 import eu.kanade.tachiyomi.data.database.queries.TrackQueries
 import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory
@@ -37,7 +40,8 @@ open class DatabaseHelper(
     CategoryQueries,
     MangaCategoryQueries,
     HistoryQueries,
-    SearchMetadataQueries {
+    SearchMetadataQueries,
+    SavedSearchQueries {
     private val configuration =
         SupportSQLiteOpenHelper.Configuration
             .builder(context)
@@ -56,6 +60,7 @@ open class DatabaseHelper(
             .addTypeMapping(MangaCategory::class.java, MangaCategoryTypeMapping())
             .addTypeMapping(SearchMetadata::class.java, SearchMetadataTypeMapping())
             .addTypeMapping(History::class.java, HistoryTypeMapping())
+            .addTypeMapping(SavedSearch::class.java, SavedSearchTypeMapping())
             .build()
 
     inline fun inTransaction(block: () -> Unit) = db.inTransaction(block)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/DbOpenCallback.kt
@@ -7,6 +7,7 @@ import eu.kanade.tachiyomi.data.database.tables.ChapterTable
 import eu.kanade.tachiyomi.data.database.tables.HistoryTable
 import eu.kanade.tachiyomi.data.database.tables.MangaCategoryTable
 import eu.kanade.tachiyomi.data.database.tables.MangaTable
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable
 import eu.kanade.tachiyomi.data.database.tables.TrackTable
 
 class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
@@ -19,7 +20,7 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
         /**
          * Version of the database.
          */
-        const val DATABASE_VERSION = 20
+        const val DATABASE_VERSION = 21
     }
 
     override fun onOpen(db: SupportSQLiteDatabase) {
@@ -46,11 +47,13 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
             execSQL(CategoryTable.createTableQuery)
             execSQL(MangaCategoryTable.createTableQuery)
             execSQL(HistoryTable.createTableQuery)
+            execSQL(SavedSearchTable.createTableQuery)
 
             // DB indexes
             execSQL(MangaTable.createUrlIndexQuery)
             execSQL(MangaTable.createLibraryIndexQuery)
             execSQL(MangaTable.createSourceIndexQuery)
+            execSQL(SavedSearchTable.createSourceIndexQuery)
             execSQL(ChapterTable.createMangaIdIndexQuery)
             execSQL(ChapterTable.createUnreadChaptersIndexQuery)
             execSQL(ChapterTable.createUrlIndexQuery)
@@ -147,6 +150,10 @@ class DbOpenCallback : SupportSQLiteOpenHelper.Callback(DATABASE_VERSION) {
             db.execSQL(MangaTable.createSourceIndexQuery)
             // Redundant with the UNIQUE constraint on history_chapter_id
             db.execSQL(HistoryTable.dropChapterIdIndexQuery)
+        }
+        if (oldVersion < 21) {
+            db.execSQL(SavedSearchTable.createTableQuery)
+            db.execSQL(SavedSearchTable.createSourceIndexQuery)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/SavedSearchTypeMapping.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/mappers/SavedSearchTypeMapping.kt
@@ -1,0 +1,72 @@
+package eu.kanade.tachiyomi.data.database.mappers
+
+import android.content.ContentValues
+import android.database.Cursor
+import com.pushtorefresh.storio.sqlite.SQLiteTypeMapping
+import com.pushtorefresh.storio.sqlite.operations.delete.DefaultDeleteResolver
+import com.pushtorefresh.storio.sqlite.operations.get.DefaultGetResolver
+import com.pushtorefresh.storio.sqlite.operations.put.DefaultPutResolver
+import com.pushtorefresh.storio.sqlite.queries.DeleteQuery
+import com.pushtorefresh.storio.sqlite.queries.InsertQuery
+import com.pushtorefresh.storio.sqlite.queries.UpdateQuery
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
+import eu.kanade.tachiyomi.data.database.models.SavedSearchImpl
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.COL_FILTERS_JSON
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.COL_ID
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.COL_NAME
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.COL_QUERY
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.COL_SOURCE
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable.TABLE
+
+class SavedSearchTypeMapping :
+    SQLiteTypeMapping<SavedSearch>(
+        SavedSearchPutResolver(),
+        SavedSearchGetResolver(),
+        SavedSearchDeleteResolver(),
+    )
+
+class SavedSearchPutResolver : DefaultPutResolver<SavedSearch>() {
+    override fun mapToInsertQuery(obj: SavedSearch) =
+        InsertQuery
+            .builder()
+            .table(TABLE)
+            .build()
+
+    override fun mapToUpdateQuery(obj: SavedSearch) =
+        UpdateQuery
+            .builder()
+            .table(TABLE)
+            .where("$COL_ID = ?")
+            .whereArgs(obj.id)
+            .build()
+
+    override fun mapToContentValues(obj: SavedSearch) =
+        ContentValues(5).apply {
+            put(COL_ID, obj.id)
+            put(COL_SOURCE, obj.source)
+            put(COL_NAME, obj.name)
+            put(COL_QUERY, obj.query)
+            put(COL_FILTERS_JSON, obj.filtersJson)
+        }
+}
+
+class SavedSearchGetResolver : DefaultGetResolver<SavedSearch>() {
+    override fun mapFromCursor(cursor: Cursor): SavedSearch =
+        SavedSearchImpl().apply {
+            id = cursor.getLong(cursor.getColumnIndex(COL_ID))
+            source = cursor.getLong(cursor.getColumnIndex(COL_SOURCE))
+            name = cursor.getString(cursor.getColumnIndex(COL_NAME))
+            query = cursor.getString(cursor.getColumnIndex(COL_QUERY))
+            filtersJson = cursor.getString(cursor.getColumnIndex(COL_FILTERS_JSON))
+        }
+}
+
+class SavedSearchDeleteResolver : DefaultDeleteResolver<SavedSearch>() {
+    override fun mapToDeleteQuery(obj: SavedSearch) =
+        DeleteQuery
+            .builder()
+            .table(TABLE)
+            .where("$COL_ID = ?")
+            .whereArgs(obj.id)
+            .build()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/SavedSearch.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/SavedSearch.kt
@@ -1,0 +1,22 @@
+package eu.kanade.tachiyomi.data.database.models
+
+import java.io.Serializable
+
+interface SavedSearch : Serializable {
+    var id: Long?
+
+    var source: Long
+
+    var name: String
+
+    var query: String?
+
+    var filtersJson: String?
+
+    companion object {
+        fun create(source: Long): SavedSearch =
+            SavedSearchImpl().apply {
+                this.source = source
+            }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/SavedSearchImpl.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/SavedSearchImpl.kt
@@ -1,0 +1,13 @@
+package eu.kanade.tachiyomi.data.database.models
+
+class SavedSearchImpl : SavedSearch {
+    override var id: Long? = null
+
+    override var source: Long = 0
+
+    override lateinit var name: String
+
+    override var query: String? = null
+
+    override var filtersJson: String? = null
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
@@ -6,7 +6,6 @@ import eu.kanade.tachiyomi.data.database.models.SavedSearch
 import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable
 
 interface SavedSearchQueries : DbProvider {
-
     fun getSavedSearches(sourceId: Long) =
         db
             .get()

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
@@ -6,16 +6,6 @@ import eu.kanade.tachiyomi.data.database.models.SavedSearch
 import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable
 
 interface SavedSearchQueries : DbProvider {
-    fun getSavedSearches() =
-        db
-            .get()
-            .listOfObjects(SavedSearch::class.java)
-            .withQuery(
-                Query
-                    .builder()
-                    .table(SavedSearchTable.TABLE)
-                    .build(),
-            ).prepare()
 
     fun getSavedSearches(sourceId: Long) =
         db
@@ -32,9 +22,5 @@ interface SavedSearchQueries : DbProvider {
 
     fun insertSavedSearch(savedSearch: SavedSearch) = db.put().`object`(savedSearch).prepare()
 
-    fun insertSavedSearches(savedSearches: List<SavedSearch>) = db.put().objects(savedSearches).prepare()
-
     fun deleteSavedSearch(savedSearch: SavedSearch) = db.delete().`object`(savedSearch).prepare()
-
-    fun deleteSavedSearches(savedSearches: List<SavedSearch>) = db.delete().objects(savedSearches).prepare()
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/queries/SavedSearchQueries.kt
@@ -1,0 +1,40 @@
+package eu.kanade.tachiyomi.data.database.queries
+
+import com.pushtorefresh.storio.sqlite.queries.Query
+import eu.kanade.tachiyomi.data.database.DbProvider
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
+import eu.kanade.tachiyomi.data.database.tables.SavedSearchTable
+
+interface SavedSearchQueries : DbProvider {
+    fun getSavedSearches() =
+        db
+            .get()
+            .listOfObjects(SavedSearch::class.java)
+            .withQuery(
+                Query
+                    .builder()
+                    .table(SavedSearchTable.TABLE)
+                    .build(),
+            ).prepare()
+
+    fun getSavedSearches(sourceId: Long) =
+        db
+            .get()
+            .listOfObjects(SavedSearch::class.java)
+            .withQuery(
+                Query
+                    .builder()
+                    .table(SavedSearchTable.TABLE)
+                    .where("${SavedSearchTable.COL_SOURCE} = ?")
+                    .whereArgs(sourceId)
+                    .build(),
+            ).prepare()
+
+    fun insertSavedSearch(savedSearch: SavedSearch) = db.put().`object`(savedSearch).prepare()
+
+    fun insertSavedSearches(savedSearches: List<SavedSearch>) = db.put().objects(savedSearches).prepare()
+
+    fun deleteSavedSearch(savedSearch: SavedSearch) = db.delete().`object`(savedSearch).prepare()
+
+    fun deleteSavedSearches(savedSearches: List<SavedSearch>) = db.delete().objects(savedSearches).prepare()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/SavedSearchTable.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/tables/SavedSearchTable.kt
@@ -1,0 +1,28 @@
+package eu.kanade.tachiyomi.data.database.tables
+
+object SavedSearchTable {
+    const val TABLE = "saved_search"
+
+    const val COL_ID = "_id"
+
+    const val COL_SOURCE = "source"
+
+    const val COL_NAME = "name"
+
+    const val COL_QUERY = "query"
+
+    const val COL_FILTERS_JSON = "filters_json"
+
+    val createTableQuery: String
+        get() =
+            """CREATE TABLE $TABLE(
+            $COL_ID INTEGER NOT NULL PRIMARY KEY,
+            $COL_SOURCE INTEGER NOT NULL,
+            $COL_NAME TEXT NOT NULL,
+            $COL_QUERY TEXT,
+            $COL_FILTERS_JSON TEXT
+            )"""
+
+    val createSourceIndexQuery: String
+        get() = "CREATE INDEX ${TABLE}_${COL_SOURCE}_index ON $TABLE($COL_SOURCE)"
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceController.kt
@@ -9,6 +9,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import androidx.appcompat.widget.PopupMenu
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
@@ -20,6 +21,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bluelinelabs.conductor.ControllerChangeHandler
 import com.bluelinelabs.conductor.ControllerChangeType
 import com.google.android.material.behavior.HideViewOnScrollBehavior
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -374,7 +376,6 @@ open class BrowseSourceController(
         if (filterSheet != null) return
         val sheet = SourceFilterSheet(activity!!)
         filterSheet = sheet
-        sheet.setFilters(presenter.filterItems)
         presenter.filtersChanged = false
         val oldFilters = mutableListOf<Any?>()
         for (i in presenter.sourceFilters) {
@@ -425,12 +426,49 @@ open class BrowseSourceController(
             presenter.sourceFilters = newFilters
             sheet.setFilters(presenter.filterItems)
         }
+
+        sheet.onSaveClicked = {
+            val dialogView = View.inflate(activity, R.layout.name_input_dialog, null)
+            val nameInput = dialogView.findViewById<EditText>(R.id.name_input)
+            MaterialAlertDialogBuilder(activity!!)
+                .setTitle(R.string.save_search)
+                .setView(dialogView)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    val name = nameInput.text.toString()
+                    if (name.isNotBlank()) {
+                        presenter.saveSearch(name)
+                        sheet.setFilters(presenter.filterItems)
+                    }
+                }.setNegativeButton(android.R.string.cancel, null)
+                .show()
+        }
+
+        sheet.onSavedSearchClicked = { savedSearch ->
+            presenter.loadSearch(savedSearch)
+            showProgressBar()
+            adapter?.clear()
+            presenter.restartPager(presenter.query, presenter.sourceFilters)
+            updatePopLatestIcons()
+        }
+
+        sheet.onSavedSearchLongClicked = { savedSearch ->
+            MaterialAlertDialogBuilder(activity!!)
+                .setTitle(R.string.delete_search)
+                .setMessage(activity!!.getString(R.string.delete_search_confirmation, savedSearch.name))
+                .setPositiveButton(R.string.delete) { _, _ ->
+                    presenter.deleteSearch(savedSearch)
+                    sheet.setFilters(presenter.filterItems)
+                }.setNegativeButton(android.R.string.cancel, null)
+                .show()
+        }
+
         sheet.setOnDismissListener {
             filterSheet = null
         }
         sheet.setOnCancelListener {
             filterSheet = null
         }
+        sheet.setFilters(presenter.filterItems)
         sheet.show()
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourceController.kt
@@ -445,6 +445,15 @@ open class BrowseSourceController(
 
         sheet.onSavedSearchClicked = { savedSearch ->
             presenter.loadSearch(savedSearch)
+            if (presenter.lastSkippedFilterNames.isNotEmpty()) {
+                binding.sourceLayout.snack(
+                    activity!!.getString(
+                        R.string.filters_not_restored,
+                        presenter.lastSkippedFilterNames.joinToString(),
+                    ),
+                    Snackbar.LENGTH_LONG,
+                )
+            }
             showProgressBar()
             adapter?.clear()
             presenter.restartPager(presenter.query, presenter.sourceFilters)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
@@ -72,6 +72,10 @@ open class BrowseSourcePresenter(
 
     val filterSerializer = FilterSerializer()
 
+    /** Names of filters that couldn't be restored on the most recent [loadSearch] call. */
+    var lastSkippedFilterNames: List<String> = emptyList()
+        private set
+
     /**
      * Modifiable list of filters.
      */
@@ -352,12 +356,14 @@ open class BrowseSourcePresenter(
     fun loadSearch(savedSearch: SavedSearch) {
         query = savedSearch.query ?: ""
         sourceFilters = source.getFilterList()
+        lastSkippedFilterNames = emptyList()
         savedSearch.filtersJson?.let {
             try {
                 val json =
                     kotlinx.serialization.json.Json
                         .decodeFromString<kotlinx.serialization.json.JsonArray>(it)
                 filterSerializer.deserialize(sourceFilters, json)
+                lastSkippedFilterNames = filterSerializer.skippedFilterNames
             } catch (e: Exception) {
                 Timber.e(e, "Failed to restore filters for saved search ${savedSearch.name}")
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
@@ -353,10 +353,14 @@ open class BrowseSourcePresenter(
         query = savedSearch.query ?: ""
         sourceFilters = source.getFilterList()
         savedSearch.filtersJson?.let {
-            val json =
-                kotlinx.serialization.json.Json
-                    .decodeFromString<kotlinx.serialization.json.JsonArray>(it)
-            filterSerializer.deserialize(sourceFilters, json)
+            try {
+                val json =
+                    kotlinx.serialization.json.Json
+                        .decodeFromString<kotlinx.serialization.json.JsonArray>(it)
+                filterSerializer.deserialize(sourceFilters, json)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to restore filters for saved search ${savedSearch.name}")
+            }
         }
         filterItems = sourceFilters.toItems()
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/BrowseSourcePresenter.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.DatabaseHelper
 import eu.kanade.tachiyomi.data.database.models.Category
 import eu.kanade.tachiyomi.data.database.models.Manga
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
 import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.source.CatalogueSource
@@ -26,6 +27,7 @@ import eu.kanade.tachiyomi.ui.source.filter.TextItem
 import eu.kanade.tachiyomi.ui.source.filter.TextSectionItem
 import eu.kanade.tachiyomi.ui.source.filter.TriStateItem
 import eu.kanade.tachiyomi.ui.source.filter.TriStateSectionItem
+import eu.kanade.tachiyomi.util.filter.FilterSerializer
 import eu.kanade.tachiyomi.util.manga.duplicateLibraryMangaIds
 import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.withUIContext
@@ -66,6 +68,10 @@ open class BrowseSourcePresenter(
     val page: Int
         get() = pager.currentPage
 
+    var savedSearches = mutableListOf<SavedSearch>()
+
+    val filterSerializer = FilterSerializer()
+
     /**
      * Modifiable list of filters.
      */
@@ -103,6 +109,7 @@ open class BrowseSourcePresenter(
         if (!::pager.isInitialized) {
             source = sourceManager.get(sourceId) as? CatalogueSource ?: return
 
+            loadSavedSearches()
             sourceFilters = source.getFilterList()
 
             if (oldFilters.isEmpty()) {
@@ -320,6 +327,40 @@ open class BrowseSourcePresenter(
         restartPager(filters = filters)
     }
 
+    fun loadSavedSearches() {
+        savedSearches = db.getSavedSearches(sourceId).executeAsBlocking().toMutableList()
+    }
+
+    fun saveSearch(name: String) {
+        val savedSearch =
+            SavedSearch.create(sourceId).apply {
+                this.name = name
+                this.query = this@BrowseSourcePresenter.query
+                this.filtersJson = filterSerializer.serialize(sourceFilters).toString()
+            }
+        db.insertSavedSearch(savedSearch).executeAsBlocking()
+        loadSavedSearches()
+        filterItems = sourceFilters.toItems()
+    }
+
+    fun deleteSearch(savedSearch: SavedSearch) {
+        db.deleteSavedSearch(savedSearch).executeAsBlocking()
+        loadSavedSearches()
+        filterItems = sourceFilters.toItems()
+    }
+
+    fun loadSearch(savedSearch: SavedSearch) {
+        query = savedSearch.query ?: ""
+        sourceFilters = source.getFilterList()
+        savedSearch.filtersJson?.let {
+            val json =
+                kotlinx.serialization.json.Json
+                    .decodeFromString<kotlinx.serialization.json.JsonArray>(it)
+            filterSerializer.deserialize(sourceFilters, json)
+        }
+        filterItems = sourceFilters.toItems()
+    }
+
     open fun createPager(
         query: String,
         filters: FilterList,
@@ -331,42 +372,51 @@ open class BrowseSourcePresenter(
             BrowseSourcePager(source, query, filters)
         }
 
-    private fun FilterList.toItems(): List<IFlexible<*>> =
-        mapNotNull { filter ->
-            when (filter) {
-                is Filter.Header -> HeaderItem(filter)
-                is Filter.Separator -> SeparatorItem(filter)
-                is Filter.CheckBox -> CheckboxItem(filter)
-                is Filter.TriState -> TriStateItem(filter)
-                is Filter.Text -> TextItem(filter)
-                is Filter.Select<*> -> SelectItem(filter)
-                is Filter.Group<*> -> {
-                    val group = GroupItem(filter)
-                    val subItems =
-                        filter.state.mapNotNull { type ->
-                            when (type) {
-                                is Filter.CheckBox -> CheckboxSectionItem(type)
-                                is Filter.TriState -> TriStateSectionItem(type)
-                                is Filter.Text -> TextSectionItem(type)
-                                is Filter.Select<*> -> SelectSectionItem(type)
-                                else -> null
-                            }
-                        }
-                    subItems.forEach { it.header = group }
-                    group.subItems = subItems
-                    group
-                }
-                is Filter.Sort -> {
-                    val group = SortGroup(filter)
-                    val subItems =
-                        filter.values.map {
-                            SortItem(it, group)
-                        }
-                    group.subItems = subItems
-                    group
-                }
-            }
+    private fun FilterList.toItems(): List<IFlexible<*>> {
+        val items = mutableListOf<IFlexible<*>>()
+        if (savedSearches.isNotEmpty()) {
+            items.add(SavedSearchesItem(savedSearches))
+            items.add(SeparatorItem(Filter.Separator()))
         }
+        items.addAll(
+            mapNotNull { filter ->
+                when (filter) {
+                    is Filter.Header -> HeaderItem(filter)
+                    is Filter.Separator -> SeparatorItem(filter)
+                    is Filter.CheckBox -> CheckboxItem(filter)
+                    is Filter.TriState -> TriStateItem(filter)
+                    is Filter.Text -> TextItem(filter)
+                    is Filter.Select<*> -> SelectItem(filter)
+                    is Filter.Group<*> -> {
+                        val group = GroupItem(filter)
+                        val subItems =
+                            filter.state.mapNotNull { type ->
+                                when (type) {
+                                    is Filter.CheckBox -> CheckboxSectionItem(type)
+                                    is Filter.TriState -> TriStateSectionItem(type)
+                                    is Filter.Text -> TextSectionItem(type)
+                                    is Filter.Select<*> -> SelectSectionItem(type)
+                                    else -> null
+                                }
+                            }
+                        subItems.forEach { it.header = group }
+                        group.subItems = subItems
+                        group
+                    }
+                    is Filter.Sort -> {
+                        val group = SortGroup(filter)
+                        val subItems =
+                            filter.values.map {
+                                SortItem(it, group)
+                            }
+                        group.subItems = subItems
+                        group
+                    }
+                }
+            },
+        )
+        return items
+    }
 
     /**
      * Get user categories.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SavedSearchesItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SavedSearchesItem.kt
@@ -1,0 +1,86 @@
+package eu.kanade.tachiyomi.ui.source.browse
+
+import android.content.res.ColorStateList
+import android.view.View
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.flexbox.FlexboxLayout
+import com.google.android.material.chip.Chip
+import eu.davidea.flexibleadapter.FlexibleAdapter
+import eu.davidea.flexibleadapter.items.AbstractHeaderItem
+import eu.davidea.flexibleadapter.items.IFlexible
+import eu.davidea.viewholders.FlexibleViewHolder
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
+import eu.kanade.tachiyomi.databinding.SavedSearchesItemBinding
+import eu.kanade.tachiyomi.util.system.dpToPx
+import eu.kanade.tachiyomi.util.system.getResourceColor
+
+class SavedSearchesItem(
+    val savedSearches: List<SavedSearch>,
+) : AbstractHeaderItem<SavedSearchesItem.Holder>() {
+    var onSavedSearchClicked: (SavedSearch) -> Unit = {}
+    var onSavedSearchLongClicked: (SavedSearch) -> Unit = {}
+
+    override fun getLayoutRes(): Int = R.layout.saved_searches_item
+
+    override fun createViewHolder(
+        view: View,
+        adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
+    ): Holder = Holder(view, adapter)
+
+    override fun bindViewHolder(
+        adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
+        holder: Holder,
+        position: Int,
+        payloads: MutableList<Any?>?,
+    ) {
+        holder.bind(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other is SavedSearchesItem) {
+            return savedSearches == other.savedSearches
+        }
+        return false
+    }
+
+    override fun hashCode(): Int = savedSearches.hashCode()
+
+    class Holder(
+        view: View,
+        adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>,
+    ) : FlexibleViewHolder(view, adapter) {
+        private val binding = SavedSearchesItemBinding.bind(view)
+
+        fun bind(item: SavedSearchesItem) {
+            binding.flexbox.removeAllViews()
+            item.savedSearches.forEach { savedSearch ->
+                val chip =
+                    Chip(binding.root.context).apply {
+                        text = savedSearch.name
+                        setOnClickListener { item.onSavedSearchClicked(savedSearch) }
+                        setOnLongClickListener {
+                            item.onSavedSearchLongClicked(savedSearch)
+                            true
+                        }
+                        chipBackgroundColor =
+                            ColorStateList.valueOf(
+                                context.getResourceColor(R.attr.colorSecondaryContainer),
+                            )
+                        setTextColor(context.getResourceColor(R.attr.colorOnSecondaryContainer))
+                        chipStrokeWidth = 0f
+                        layoutParams =
+                            FlexboxLayout
+                                .LayoutParams(
+                                    FlexboxLayout.LayoutParams.WRAP_CONTENT,
+                                    FlexboxLayout.LayoutParams.WRAP_CONTENT,
+                                ).apply {
+                                    setMargins(0, 0, 8.dpToPx, 8.dpToPx)
+                                }
+                    }
+                binding.flexbox.addView(chip)
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceFilterSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceFilterSheet.kt
@@ -11,6 +11,7 @@ import androidx.core.view.updatePaddingRelative
 import androidx.recyclerview.widget.RecyclerView
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.IFlexible
+import eu.kanade.tachiyomi.data.database.models.SavedSearch
 import eu.kanade.tachiyomi.databinding.SourceFilterSheetBinding
 import eu.kanade.tachiyomi.ui.main.MainActivity
 import eu.kanade.tachiyomi.util.system.dpToPx
@@ -21,7 +22,9 @@ import eu.kanade.tachiyomi.widget.StickyFooterBottomSheetDialog
 
 class SourceFilterSheet(
     val activity: Activity,
-) : StickyFooterBottomSheetDialog<SourceFilterSheetBinding>(activity) {
+) : StickyFooterBottomSheetDialog<SourceFilterSheetBinding>(activity),
+    FlexibleAdapter.OnItemClickListener,
+    FlexibleAdapter.OnItemLongClickListener {
     private var filterChanged = true
 
     val adapter: FlexibleAdapter<IFlexible<*>> =
@@ -31,6 +34,12 @@ class SourceFilterSheet(
     var onSearchClicked = {}
 
     var onResetClicked = {}
+
+    var onSaveClicked = {}
+
+    var onSavedSearchClicked: (SavedSearch) -> Unit = {}
+
+    var onSavedSearchLongClicked: (SavedSearch) -> Unit = {}
 
     override var recyclerView: RecyclerView? = binding.filtersRecycler
 
@@ -42,6 +51,7 @@ class SourceFilterSheet(
     init {
         binding.searchBtn.setOnClickListener { dismiss() }
         binding.resetBtn.setOnClickListener { onResetClicked() }
+        binding.saveBtn.setOnClickListener { onSaveClicked() }
 
         sheetBehavior.peekHeight = 450.dpToPx
         sheetBehavior.collapse()
@@ -82,6 +92,15 @@ class SourceFilterSheet(
         binding.filtersRecycler.clipToPadding = false
         binding.filtersRecycler.adapter = adapter
         binding.filtersRecycler.setHasFixedSize(false)
+        adapter.addListener(this)
+    }
+
+    override fun onItemClick(
+        view: View?,
+        position: Int,
+    ): Boolean = true
+
+    override fun onItemLongClick(position: Int) {
     }
 
     fun setCardViewMax(topInset: Int) {
@@ -128,6 +147,13 @@ class SourceFilterSheet(
     }
 
     fun setFilters(items: List<IFlexible<*>>) {
+        items.filterIsInstance<SavedSearchesItem>().forEach {
+            it.onSavedSearchClicked = { savedSearch ->
+                onSavedSearchClicked(savedSearch)
+                dismiss()
+            }
+            it.onSavedSearchLongClicked = onSavedSearchLongClicked
+        }
         adapter.updateDataSet(items)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceFilterSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/SourceFilterSheet.kt
@@ -22,9 +22,7 @@ import eu.kanade.tachiyomi.widget.StickyFooterBottomSheetDialog
 
 class SourceFilterSheet(
     val activity: Activity,
-) : StickyFooterBottomSheetDialog<SourceFilterSheetBinding>(activity),
-    FlexibleAdapter.OnItemClickListener,
-    FlexibleAdapter.OnItemLongClickListener {
+) : StickyFooterBottomSheetDialog<SourceFilterSheetBinding>(activity) {
     private var filterChanged = true
 
     val adapter: FlexibleAdapter<IFlexible<*>> =
@@ -92,15 +90,6 @@ class SourceFilterSheet(
         binding.filtersRecycler.clipToPadding = false
         binding.filtersRecycler.adapter = adapter
         binding.filtersRecycler.setHasFixedSize(false)
-        adapter.addListener(this)
-    }
-
-    override fun onItemClick(
-        view: View?,
-        position: Int,
-    ): Boolean = true
-
-    override fun onItemLongClick(position: Int) {
     }
 
     fun setCardViewMax(topInset: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializer.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.double
 import kotlinx.serialization.json.float
 import kotlinx.serialization.json.int
@@ -32,6 +33,17 @@ class FilterSerializer {
             SortSerializer(this),
         )
 
+    private val _skippedFilterNames = mutableListOf<String>()
+
+    /**
+     * Names of saved filters that couldn't be matched to a live filter, or that failed to
+     * restore, during the most recent [deserialize] call — for example because the source's
+     * extension added, removed, renamed, or reordered a filter since the search was saved.
+     * Cleared at the start of every [deserialize] call, so read it right after calling that.
+     */
+    val skippedFilterNames: List<String>
+        get() = _skippedFilterNames.distinct()
+
     fun serialize(filters: FilterList) =
         buildJsonArray {
             filters.filterIsInstance<Filter<Any?>>().forEach {
@@ -40,63 +52,58 @@ class FilterSerializer {
         }
 
     fun serialize(filter: Filter<Any?>): JsonObject =
-        serializers
-            .filterIsInstance<Serializer<Filter<Any?>>>()
-            .firstOrNull {
-                filter::class.isSubclassOf(it.clazz)
-            }?.let { serializer ->
-                buildJsonObject {
-                    with(serializer) { serialize(filter) }
+        serializerFor(filter)?.let { serializer ->
+            buildJsonObject {
+                with(serializer) { serialize(filter) }
 
-                    val classMappings = mutableListOf<Pair<String, Any>>()
+                val classMappings = mutableListOf<Pair<String, Any>>()
 
-                    serializer.mappings().forEach {
-                        val res = it.second.get(filter)
-                        put(it.first, res.toString())
-                        classMappings += it.first to (res?.javaClass?.name ?: "null")
-                    }
-
-                    putJsonObject(CLASS_MAPPINGS) {
-                        classMappings.forEach { (t, u) ->
-                            put(t, u.toString())
-                        }
-                    }
-
-                    put(TYPE, serializer.type)
+                serializer.mappings().forEach {
+                    val res = it.second.get(filter)
+                    put(it.first, res.toString())
+                    classMappings += it.first to (res?.javaClass?.name ?: "null")
                 }
-            } ?: throw IllegalArgumentException("Cannot serialize this Filter object!")
+
+                putJsonObject(CLASS_MAPPINGS) {
+                    classMappings.forEach { (t, u) ->
+                        put(t, u.toString())
+                    }
+                }
+
+                put(TYPE, serializer.type)
+            }
+        } ?: throw IllegalArgumentException("Cannot serialize this Filter object!")
 
     fun deserialize(
         filters: FilterList,
         json: JsonArray,
     ) {
-        filters.filterIsInstance<Filter<Any?>>().zip(json).forEach { (filter, obj) ->
-            try {
-                deserialize(filter, obj.jsonObject)
-            } catch (e: Exception) {
-                Timber.e(e)
-            }
-        }
+        _skippedFilterNames.clear()
+        deserializeMatchingByName(filters.filterIsInstance<Filter<Any?>>(), json)
     }
 
     fun deserialize(
         filter: Filter<Any?>,
         json: JsonObject,
     ) {
+        val type = json[TYPE]?.jsonPrimitive?.contentOrNull ?: return
         val serializer =
             serializers
                 .filterIsInstance<Serializer<Filter<Any?>>>()
                 .firstOrNull {
-                    it.type == json[TYPE]!!.jsonPrimitive.content
+                    it.type == type
                 } ?: throw IllegalArgumentException("Cannot deserialize this type!")
 
         serializer.deserialize(json, filter)
 
-        serializer.mappings().forEach {
-            if (it.second is KMutableProperty1) {
-                val obj = json[it.first]!!.jsonPrimitive
+        val classMappings = json[CLASS_MAPPINGS]?.jsonObject ?: return
+
+        serializer.mappings().forEach { (key, property) ->
+            if (property is KMutableProperty1) {
+                val obj = json[key]?.jsonPrimitive ?: return@forEach
+                val className = classMappings[key]?.jsonPrimitive?.contentOrNull ?: return@forEach
                 val res: Any? =
-                    when (json[CLASS_MAPPINGS]!!.jsonObject[it.first]!!.jsonPrimitive.content) {
+                    when (className) {
                         java.lang.Integer::class.java.name -> obj.int
                         java.lang.Long::class.java.name -> obj.long
                         java.lang.Float::class.java.name -> obj.float
@@ -110,12 +117,68 @@ class FilterSerializer {
                         else -> throw IllegalArgumentException("Cannot deserialize this type!")
                     }
                 @Suppress("UNCHECKED_CAST")
-                (it.second as KMutableProperty1<in Filter<Any?>, in Any?>).set(filter, res)
+                (property as KMutableProperty1<in Filter<Any?>, in Any?>).set(filter, res)
             }
         }
     }
 
+    /**
+     * Matches each saved filter entry in [json] to a filter in [liveFilters] by name and type,
+     * then restores its saved value onto that filter — instead of pairing them up by list
+     * position.
+     *
+     * Position-based matching breaks silently if a source's filter list changes between when a
+     * search was saved and when it's re-applied, e.g. an extension update that adds, removes, or
+     * reorders a filter. A saved filter with no matching name+type is simply left at its default
+     * rather than having its value applied to the wrong filter, and its name is added to
+     * [skippedFilterNames] so the caller can let the user know. If more than one live filter
+     * shares the same name and type, they're paired up in the order they appear. [parentName]
+     * labels filters nested inside a group, e.g. "Genre: Fantasy".
+     */
+    internal fun deserializeMatchingByName(
+        liveFilters: List<Filter<Any?>>,
+        json: JsonArray,
+        parentName: String? = null,
+    ) {
+        val usedIndices = mutableSetOf<Int>()
+
+        json.forEach { element ->
+            val obj = element as? JsonObject ?: return@forEach
+            var label = "?"
+            try {
+                val savedName = obj[NAME]?.jsonPrimitive?.contentOrNull
+                val savedType = obj[TYPE]?.jsonPrimitive?.contentOrNull
+                label = if (parentName != null) "$parentName: ${savedName ?: "?"}" else savedName ?: "?"
+
+                val matchIndex =
+                    liveFilters.indices.firstOrNull { index ->
+                        index !in usedIndices &&
+                            liveFilters[index].name == savedName &&
+                            serializerFor(liveFilters[index])?.type == savedType
+                    }
+
+                if (matchIndex == null) {
+                    _skippedFilterNames += label
+                    Timber.w("No filter matches saved filter \"$savedName\" ($savedType); skipping")
+                    return@forEach
+                }
+
+                usedIndices += matchIndex
+                deserialize(liveFilters[matchIndex], obj)
+            } catch (e: Exception) {
+                _skippedFilterNames += label
+                Timber.e(e)
+            }
+        }
+    }
+
+    private fun serializerFor(filter: Filter<Any?>): Serializer<Filter<Any?>>? =
+        serializers
+            .filterIsInstance<Serializer<Filter<Any?>>>()
+            .firstOrNull { filter::class.isSubclassOf(it.clazz) }
+
     companion object {
+        const val NAME = "name"
         const val TYPE = "_type"
         const val CLASS_MAPPINGS = "_cmaps"
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializer.kt
@@ -1,0 +1,122 @@
+package eu.kanade.tachiyomi.util.filter
+
+import eu.kanade.tachiyomi.source.model.Filter
+import eu.kanade.tachiyomi.source.model.FilterList
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.float
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import timber.log.Timber
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.isSubclassOf
+
+class FilterSerializer {
+    private val serializers =
+        listOf<Serializer<*>>(
+            HeaderSerializer(this),
+            SeparatorSerializer(this),
+            SelectSerializer(this),
+            TextSerializer(this),
+            CheckboxSerializer(this),
+            TriStateSerializer(this),
+            GroupSerializer(this),
+            SortSerializer(this),
+        )
+
+    fun serialize(filters: FilterList) =
+        buildJsonArray {
+            filters.filterIsInstance<Filter<Any?>>().forEach {
+                add(serialize(it))
+            }
+        }
+
+    fun serialize(filter: Filter<Any?>): JsonObject =
+        serializers
+            .filterIsInstance<Serializer<Filter<Any?>>>()
+            .firstOrNull {
+                filter::class.isSubclassOf(it.clazz)
+            }?.let { serializer ->
+                buildJsonObject {
+                    with(serializer) { serialize(filter) }
+
+                    val classMappings = mutableListOf<Pair<String, Any>>()
+
+                    serializer.mappings().forEach {
+                        val res = it.second.get(filter)
+                        put(it.first, res.toString())
+                        classMappings += it.first to (res?.javaClass?.name ?: "null")
+                    }
+
+                    putJsonObject(CLASS_MAPPINGS) {
+                        classMappings.forEach { (t, u) ->
+                            put(t, u.toString())
+                        }
+                    }
+
+                    put(TYPE, serializer.type)
+                }
+            } ?: throw IllegalArgumentException("Cannot serialize this Filter object!")
+
+    fun deserialize(
+        filters: FilterList,
+        json: JsonArray,
+    ) {
+        filters.filterIsInstance<Filter<Any?>>().zip(json).forEach { (filter, obj) ->
+            try {
+                deserialize(filter, obj.jsonObject)
+            } catch (e: Exception) {
+                Timber.e(e)
+            }
+        }
+    }
+
+    fun deserialize(
+        filter: Filter<Any?>,
+        json: JsonObject,
+    ) {
+        val serializer =
+            serializers
+                .filterIsInstance<Serializer<Filter<Any?>>>()
+                .firstOrNull {
+                    it.type == json[TYPE]!!.jsonPrimitive.content
+                } ?: throw IllegalArgumentException("Cannot deserialize this type!")
+
+        serializer.deserialize(json, filter)
+
+        serializer.mappings().forEach {
+            if (it.second is KMutableProperty1) {
+                val obj = json[it.first]!!.jsonPrimitive
+                val res: Any? =
+                    when (json[CLASS_MAPPINGS]!!.jsonObject[it.first]!!.jsonPrimitive.content) {
+                        java.lang.Integer::class.java.name -> obj.int
+                        java.lang.Long::class.java.name -> obj.long
+                        java.lang.Float::class.java.name -> obj.float
+                        java.lang.Double::class.java.name -> obj.double
+                        java.lang.String::class.java.name -> obj.content
+                        java.lang.Boolean::class.java.name -> obj.boolean
+                        java.lang.Byte::class.java.name -> obj.content.toByte()
+                        java.lang.Short::class.java.name -> obj.content.toShort()
+                        java.lang.Character::class.java.name -> obj.content[0]
+                        "null" -> null
+                        else -> throw IllegalArgumentException("Cannot deserialize this type!")
+                    }
+                @Suppress("UNCHECKED_CAST")
+                (it.second as KMutableProperty1<in Filter<Any?>, in Any?>).set(filter, res)
+            }
+        }
+    }
+
+    companion object {
+        const val TYPE = "_type"
+        const val CLASS_MAPPINGS = "_cmaps"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializerModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializerModels.kt
@@ -1,0 +1,247 @@
+package eu.kanade.tachiyomi.util.filter
+
+import eu.kanade.tachiyomi.source.model.Filter
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+
+interface Serializer<in T : Filter<out Any?>> {
+    fun JsonObjectBuilder.serialize(filter: T) {}
+
+    fun deserialize(
+        json: JsonObject,
+        filter: T,
+    ) {}
+
+    /**
+     * Automatic two-way mappings between fields and JSON
+     */
+    fun mappings(): List<Pair<String, KProperty1<in T, *>>> = emptyList()
+
+    val serializer: FilterSerializer
+    val type: String
+    val clazz: KClass<in T>
+}
+
+class HeaderSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Header> {
+    override val type = "HEADER"
+    override val clazz = Filter.Header::class
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Header::name),
+        )
+
+    companion object {
+        const val NAME = "name"
+    }
+}
+
+class SeparatorSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Separator> {
+    override val type = "SEPARATOR"
+    override val clazz = Filter.Separator::class
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Separator::name),
+        )
+
+    companion object {
+        const val NAME = "name"
+    }
+}
+
+class SelectSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Select<Any>> {
+    override val type = "SELECT"
+    override val clazz = Filter.Select::class
+
+    override fun JsonObjectBuilder.serialize(filter: Filter.Select<Any>) {
+        // Serialize values to JSON
+        putJsonArray(VALUES) {
+            filter.values
+                .map {
+                    it.toString()
+                }.forEach { add(it) }
+        }
+    }
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Select<Any>::name),
+            Pair(STATE, Filter.Select<Any>::state),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val VALUES = "values"
+        const val STATE = "state"
+    }
+}
+
+class TextSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Text> {
+    override val type = "TEXT"
+    override val clazz = Filter.Text::class
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Text::name),
+            Pair(STATE, Filter.Text::state),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val STATE = "state"
+    }
+}
+
+class CheckboxSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.CheckBox> {
+    override val type = "CHECKBOX"
+    override val clazz = Filter.CheckBox::class
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.CheckBox::name),
+            Pair(STATE, Filter.CheckBox::state),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val STATE = "state"
+    }
+}
+
+class TriStateSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.TriState> {
+    override val type = "TRISTATE"
+    override val clazz = Filter.TriState::class
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.TriState::name),
+            Pair(STATE, Filter.TriState::state),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val STATE = "state"
+    }
+}
+
+class GroupSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Group<Any?>> {
+    override val type = "GROUP"
+    override val clazz = Filter.Group::class
+
+    override fun JsonObjectBuilder.serialize(filter: Filter.Group<Any?>) {
+        putJsonArray(STATE) {
+            filter.state.forEach {
+                add(
+                    if (it is Filter<*>) {
+                        @Suppress("UNCHECKED_CAST")
+                        serializer.serialize(it as Filter<Any?>)
+                    } else {
+                        JsonNull as JsonElement
+                    },
+                )
+            }
+        }
+    }
+
+    override fun deserialize(
+        json: JsonObject,
+        filter: Filter.Group<Any?>,
+    ) {
+        json[STATE]!!.jsonArray.forEachIndexed { index, jsonElement ->
+            if (jsonElement !is JsonNull) {
+                @Suppress("UNCHECKED_CAST")
+                serializer.deserialize(filter.state[index] as Filter<Any?>, jsonElement.jsonObject)
+            }
+        }
+    }
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Group<Any?>::name),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val STATE = "state"
+    }
+}
+
+class SortSerializer(
+    override val serializer: FilterSerializer,
+) : Serializer<Filter.Sort> {
+    override val type = "SORT"
+    override val clazz = Filter.Sort::class
+
+    override fun JsonObjectBuilder.serialize(filter: Filter.Sort) {
+        // Serialize values
+        putJsonArray(VALUES) {
+            filter.values.forEach { add(it) }
+        }
+        // Serialize state
+        put(
+            STATE,
+            filter.state?.let { (index, ascending) ->
+                buildJsonObject {
+                    put(STATE_INDEX, index)
+                    put(STATE_ASCENDING, ascending)
+                }
+            } ?: (JsonNull as JsonElement),
+        )
+    }
+
+    override fun deserialize(
+        json: JsonObject,
+        filter: Filter.Sort,
+    ) {
+        // Deserialize state
+        filter.state =
+            (json[STATE] as? JsonObject)?.let {
+                Filter.Sort.Selection(
+                    it[STATE_INDEX]!!.jsonPrimitive.int,
+                    it[STATE_ASCENDING]!!.jsonPrimitive.boolean,
+                )
+            }
+    }
+
+    override fun mappings() =
+        listOf(
+            Pair(NAME, Filter.Sort::name),
+        )
+
+    companion object {
+        const val NAME = "name"
+        const val VALUES = "values"
+        const val STATE = "state"
+
+        const val STATE_INDEX = "index"
+        const val STATE_ASCENDING = "ascending"
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializerModels.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/filter/FilterSerializerModels.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -175,12 +174,10 @@ class GroupSerializer(
         json: JsonObject,
         filter: Filter.Group<Any?>,
     ) {
-        json[STATE]!!.jsonArray.forEachIndexed { index, jsonElement ->
-            if (jsonElement !is JsonNull) {
-                @Suppress("UNCHECKED_CAST")
-                serializer.deserialize(filter.state[index] as Filter<Any?>, jsonElement.jsonObject)
-            }
-        }
+        @Suppress("UNCHECKED_CAST")
+        val subFilters = filter.state.filterIsInstance<Filter<Any?>>()
+        val state = json[STATE]?.jsonArray ?: return
+        serializer.deserializeMatchingByName(subFilters, state, parentName = filter.name)
     }
 
     override fun mappings() =
@@ -224,10 +221,9 @@ class SortSerializer(
         // Deserialize state
         filter.state =
             (json[STATE] as? JsonObject)?.let {
-                Filter.Sort.Selection(
-                    it[STATE_INDEX]!!.jsonPrimitive.int,
-                    it[STATE_ASCENDING]!!.jsonPrimitive.boolean,
-                )
+                val index = it[STATE_INDEX]?.jsonPrimitive?.int ?: return@let null
+                val ascending = it[STATE_ASCENDING]?.jsonPrimitive?.boolean ?: return@let null
+                Filter.Sort.Selection(index, ascending)
             }
     }
 

--- a/app/src/main/res/layout/name_input_dialog.xml
+++ b/app/src/main/res/layout/name_input_dialog.xml
@@ -2,9 +2,9 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingLeft="24dp"
+    android:paddingStart="24dp"
     android:paddingTop="8dp"
-    android:paddingRight="24dp"
+    android:paddingEnd="24dp"
     android:paddingBottom="8dp">
 
     <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/layout/name_input_dialog.xml
+++ b/app/src/main/res/layout/name_input_dialog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="24dp"
+    android:paddingTop="8dp"
+    android:paddingRight="24dp"
+    android:paddingBottom="8dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/name_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/name"
+            android:inputType="text"
+            android:maxLines="1" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/saved_searches_item.xml
+++ b/app/src/main/res/layout/saved_searches_item.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="?attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?attr/listPreferredItemPaddingEnd"
+    android:paddingTop="12dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        android:textColor="?attr/colorOnBackground"
+        android:alpha="0.7"
+        android:text="@string/saved_searches_hold" />
+
+    <com.google.android.flexbox.FlexboxLayout
+        android:id="@+id/flexbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:flexWrap="wrap" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/source_filter_sheet.xml
+++ b/app/src/main/res/layout/source_filter_sheet.xml
@@ -64,24 +64,31 @@
             android:layout_height="wrap_content"
             android:text="@string/reset"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/search_btn"
-            app:layout_constraintHorizontal_chainStyle="spread_inside"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageButton
+            android:id="@+id/save_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/save"
+            android:padding="12dp"
+            android:src="@drawable/ic_save_24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/search_btn"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="?attr/colorOnSurface" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/search_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="48dp"
             android:layout_marginEnd="16dp"
             android:text="@string/filter"
-            app:flow_verticalBias="1.0"
-            app:iconTint="?attr/colorPrimary"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toEndOf="@id/reset_btn"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintWidth_min="150dp" />
 

--- a/app/src/main/res/layout/source_filter_sheet.xml
+++ b/app/src/main/res/layout/source_filter_sheet.xml
@@ -60,12 +60,15 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/reset_btn"
             style="@style/Widget.Material3Expressive.Button.TextButton"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:text="@string/reset"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/save_btn"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintWidth_default="wrap" />
 
         <ImageButton
             android:id="@+id/save_btn"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1248,6 +1248,7 @@
     <string name="saved_searches_hold">Saved Searches (Hold to delete)</string>
     <string name="delete_search">Delete search</string>
     <string name="delete_search_confirmation">Are you sure you want to delete the saved search %1$s?</string>
+    <string name="filters_not_restored">Some filters could not be restored: %1$s</string>
     <string name="search">Search</string>
     <string name="search_">Search %1$s</string>
     <string name="select_all">Select all</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1244,6 +1244,10 @@
     <string name="default_orientation">Default orientation</string>
     <string name="orientation">Orientation</string>
     <string name="save">Save</string>
+    <string name="save_search">Save search</string>
+    <string name="saved_searches_hold">Saved Searches (Hold to delete)</string>
+    <string name="delete_search">Delete search</string>
+    <string name="delete_search_confirmation">Are you sure you want to delete the saved search %1$s?</string>
     <string name="search">Search</string>
     <string name="search_">Search %1$s</string>
     <string name="select_all">Select all</string>


### PR DESCRIPTION
Implements the ability to save and reuse search queries and filters in the Browse Source controller.
(inspired by komikku and TachiyomiSY)
* Save Searches: New button in the filter sheet footer to save current settings.
* Quick Access: Saved searches appear as colored chips at the top of the filter list.
* Management: Tap a chip to apply the search; long-press to delete.

 Screenshot:

<img width="1264" height="1680" alt="image" src="https://github.com/user-attachments/assets/3c476ee6-114b-4763-8971-1c29180bec7e" />
