### PR TITLE
Bulk edit library items(Status, Series type, Shared tags)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
@@ -56,6 +56,29 @@ class CustomMangaManager(
     }
 
     fun saveMangaInfo(manga: MangaJson) {
+        updateMangaInfo(manga)
+        saveCustomInfo()
+    }
+
+    fun saveMangaInfo(mangas: List<MangaJson>) {
+        mangas.forEach(::updateMangaInfo)
+        saveCustomInfo()
+    }
+
+    fun getCustomInfo(manga: Manga): MangaJson? {
+        val custom = customMangaMap[manga.id] ?: return null
+        return MangaJson(
+            id = manga.id,
+            title = custom.title.takeUnless { it.isBlank() },
+            author = custom.author,
+            artist = custom.artist,
+            description = custom.description,
+            genre = custom.getGenres()?.toTypedArray(),
+            status = custom.status.takeUnless { it == -1 },
+        )
+    }
+
+    private fun updateMangaInfo(manga: MangaJson) {
         val mangaId = manga.id ?: return
         if (manga.title == null &&
             manga.author == null &&
@@ -68,7 +91,6 @@ class CustomMangaManager(
         } else {
             customMangaMap[mangaId] = manga.toManga()
         }
-        saveCustomInfo()
     }
 
     private fun saveCustomInfo() {
@@ -76,6 +98,8 @@ class CustomMangaManager(
         if (jsonElements.isNotEmpty()) {
             editJson.delete()
             editJson.writeText(Json.encodeToString(MangaList(jsonElements)))
+        } else {
+            editJson.delete()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
@@ -27,6 +27,7 @@ class BulkEditMangaDialog : DialogController {
     private val displayedTags = mutableListOf<BulkSharedTag>()
     private val tagsToAdd = mutableListOf<String>()
     private val tagsToRemove = mutableListOf<String>()
+    private var resetTags = false
 
     private val libraryController
         get() = targetController as LibraryController
@@ -68,6 +69,17 @@ class BulkEditMangaDialog : DialogController {
         binding.seriesType.setSelection(initialSeriesTypePosition)
 
         setupTagEditor()
+        binding.resetTags.setOnClickListener {
+            resetTags = true
+            tagsToAdd.clear()
+            tagsToRemove.clear()
+            displayedTags.clear()
+            displayedTags += initialState.sourceSharedTags
+            binding.addTagEditText.text?.clear()
+            binding.addTagEditText.isVisible = false
+            binding.addTagChip.isVisible = true
+            renderSharedTags()
+        }
         renderSharedTags()
 
         return activity!!
@@ -101,6 +113,7 @@ class BulkEditMangaDialog : DialogController {
                     resetStatus = resetStatus,
                     seriesType = seriesType,
                     resetSeriesType = resetSeriesType,
+                    resetTags = resetTags,
                     tagsToAdd = tagsToAdd,
                     tagsToRemove = tagsToRemove,
                 )
@@ -155,7 +168,8 @@ class BulkEditMangaDialog : DialogController {
     private fun addTag(tag: String) {
         if (displayedTags.any { it.name.equals(tag, ignoreCase = true) }) return
 
-        val originalTag = initialState.sharedTags.find { it.name.equals(tag, ignoreCase = true) }
+        val originalTags = if (resetTags) initialState.sourceSharedTags else initialState.sharedTags
+        val originalTag = originalTags.find { it.name.equals(tag, ignoreCase = true) }
         if (originalTag != null) {
             tagsToRemove.removeAll { it.equals(tag, ignoreCase = true) }
             displayedTags += originalTag
@@ -202,7 +216,10 @@ class BulkEditMangaDialog : DialogController {
         }
     }
 
-    private fun applyTagColors(chip: Chip, tag: BulkSharedTag) {
+    private fun applyTagColors(
+        chip: Chip,
+        tag: BulkSharedTag,
+    ) {
         val backgroundAttr =
             if (tag.isCustom) {
                 androidx.appcompat.R.attr.colorPrimary

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
@@ -88,6 +88,8 @@ class BulkEditMangaDialog : DialogController {
             .setView(binding.root)
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(R.string.save) { _, _ ->
+                addTags(false)
+
                 val selectedStatusPosition = binding.mangaStatus.selectedPosition
                 val resetStatus = selectedStatusPosition == statusEntries.lastIndex
                 val status =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
@@ -1,0 +1,223 @@
+package eu.kanade.tachiyomi.ui.library
+
+import android.app.Dialog
+import android.content.Context
+import android.content.res.ColorStateList
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import androidx.core.view.children
+import androidx.core.view.isVisible
+import com.google.android.material.chip.Chip
+import com.google.android.material.color.MaterialColors
+import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.databinding.BulkEditMangaDialogBinding
+import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.ui.base.controller.DialogController
+import eu.kanade.tachiyomi.util.system.materialAlertDialog
+
+class BulkEditMangaDialog : DialogController {
+    private val mangaIds: LongArray
+
+    private lateinit var binding: BulkEditMangaDialogBinding
+    private lateinit var initialState: BulkEditState
+
+    private val displayedTags = mutableListOf<BulkSharedTag>()
+    private val tagsToAdd = mutableListOf<String>()
+    private val tagsToRemove = mutableListOf<String>()
+
+    private val libraryController
+        get() = targetController as LibraryController
+
+    constructor(target: LibraryController, mangaIds: LongArray) : super(
+        Bundle().apply { putLongArray(KEY_MANGA_IDS, mangaIds) },
+    ) {
+        targetController = target
+        this.mangaIds = mangaIds
+    }
+
+    @Suppress("unused")
+    constructor(bundle: Bundle) : super(bundle) {
+        mangaIds = bundle.getLongArray(KEY_MANGA_IDS) ?: longArrayOf()
+    }
+
+    override fun onCreateDialog(savedViewState: Bundle?): Dialog {
+        binding = BulkEditMangaDialogBinding.inflate(activity!!.layoutInflater)
+        initialState = libraryController.presenter.getBulkEditState(mangaIds.toList())
+        displayedTags += initialState.sharedTags
+
+        val statusEntries =
+            listOf(activity!!.getString(R.string.bulk_edit_default)) +
+                resources!!.getStringArray(R.array.manga_statuses).toList()
+        binding.mangaStatus.setEntries(statusEntries)
+        val initialStatusPosition =
+            initialState.commonStatus
+                ?.coerceIn(SManga.UNKNOWN, SManga.ON_HIATUS)
+                ?.plus(1) ?: DEFAULT_POSITION
+        binding.mangaStatus.setSelection(initialStatusPosition)
+
+        val seriesTypeEntries =
+            listOf(activity!!.getString(R.string.bulk_edit_default)) +
+                resources!!.getStringArray(R.array.series_type).toList()
+        binding.seriesType.setEntries(seriesTypeEntries)
+        val initialSeriesTypePosition = initialState.commonSeriesType ?: DEFAULT_POSITION
+        binding.seriesType.setSelection(initialSeriesTypePosition)
+
+        setupTagEditor()
+        renderSharedTags()
+
+        return activity!!
+            .materialAlertDialog()
+            .setTitle(R.string.edit)
+            .setView(binding.root)
+            .setNegativeButton(android.R.string.cancel, null)
+            .setPositiveButton(R.string.save) { _, _ ->
+                val selectedStatusPosition = binding.mangaStatus.selectedPosition
+                val status =
+                    selectedStatusPosition
+                        .takeIf {
+                            it != DEFAULT_POSITION &&
+                                it != initialStatusPosition
+                        }?.minus(1)
+
+                val selectedSeriesTypePosition = binding.seriesType.selectedPosition
+                val seriesType =
+                    selectedSeriesTypePosition.takeIf {
+                        it != DEFAULT_POSITION &&
+                            it != initialSeriesTypePosition
+                    }
+
+                libraryController.presenter.bulkEditManga(
+                    mangaIds = mangaIds.toList(),
+                    status = status,
+                    seriesType = seriesType,
+                    tagsToAdd = tagsToAdd,
+                    tagsToRemove = tagsToRemove,
+                )
+            }.create()
+    }
+
+    private fun setupTagEditor() {
+        binding.addTagChip.setOnClickListener {
+            binding.addTagChip.isVisible = false
+            binding.addTagEditText.isVisible = true
+            binding.addTagEditText.requestFocus()
+            binding.addTagEditText.post {
+                (activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
+                    ?.showSoftInput(binding.addTagEditText, InputMethodManager.SHOW_IMPLICIT)
+            }
+        }
+        binding.addTagEditText.setOnFocusChangeListener { _, hasFocus ->
+            if (!hasFocus) addTags(false)
+        }
+        binding.addTagEditText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE) {
+                addTags(true)
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun addTags(closeKeyboard: Boolean) {
+        val newTags =
+            binding.addTagEditText.text
+                ?.toString()
+                .orEmpty()
+                .split(',')
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+
+        newTags.forEach(::addTag)
+        binding.addTagEditText.text?.clear()
+        binding.addTagEditText.isVisible = false
+        binding.addTagChip.isVisible = true
+
+        if (closeKeyboard) {
+            (activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager)
+                ?.hideSoftInputFromWindow(binding.addTagEditText.windowToken, 0)
+            binding.addTagEditText.clearFocus()
+        }
+        renderSharedTags()
+    }
+
+    private fun addTag(tag: String) {
+        if (displayedTags.any { it.name.equals(tag, ignoreCase = true) }) return
+
+        val originalTag = initialState.sharedTags.find { it.name.equals(tag, ignoreCase = true) }
+        if (originalTag != null) {
+            tagsToRemove.removeAll { it.equals(tag, ignoreCase = true) }
+            displayedTags += originalTag
+            return
+        }
+
+        if (tagsToAdd.none { it.equals(tag, ignoreCase = true) }) {
+            tagsToAdd += tag
+        }
+        displayedTags += BulkSharedTag(tag, isCustom = true, removable = true)
+    }
+
+    private fun removeTag(tag: BulkSharedTag) {
+        if (!tag.removable) return
+
+        displayedTags.removeAll { it.name.equals(tag.name, ignoreCase = true) }
+        val wasNew = tagsToAdd.removeAll { it.equals(tag.name, ignoreCase = true) }
+        if (!wasNew && tagsToRemove.none { it.equals(tag.name, ignoreCase = true) }) {
+            tagsToRemove += tag.name
+        }
+        renderSharedTags()
+    }
+
+    private fun renderSharedTags() {
+        val tagGroup = binding.sharedTags
+        tagGroup.children
+            .toList()
+            .filter { it.id != R.id.add_tag_chip && it.id != R.id.add_tag_edit_text }
+            .forEach(tagGroup::removeView)
+
+        displayedTags.forEach { tag ->
+            val chip =
+                LayoutInflater
+                    .from(tagGroup.context)
+                    .inflate(R.layout.genre_chip, tagGroup, false) as Chip
+            chip.id = View.generateViewId()
+            chip.text = tag.name
+            applyTagColors(chip, tag)
+            chip.isCloseIconVisible = tag.removable
+            if (tag.removable) {
+                chip.setOnCloseIconClickListener { removeTag(tag) }
+            }
+            tagGroup.addView(chip, (tagGroup.childCount - STATIC_TAG_EDITOR_CHILDREN).coerceAtLeast(0))
+        }
+    }
+
+    private fun applyTagColors(chip: Chip, tag: BulkSharedTag) {
+        val backgroundAttr =
+            if (tag.isCustom) {
+                androidx.appcompat.R.attr.colorPrimary
+            } else {
+                com.google.android.material.R.attr.colorSurfaceContainerHighest
+            }
+        val foregroundAttr =
+            if (tag.isCustom) {
+                com.google.android.material.R.attr.colorOnPrimary
+            } else {
+                com.google.android.material.R.attr.colorOnSurface
+            }
+        val background = MaterialColors.getColor(chip, backgroundAttr)
+        val foreground = MaterialColors.getColor(chip, foregroundAttr)
+
+        chip.chipBackgroundColor = ColorStateList.valueOf(background)
+        chip.setTextColor(foreground)
+        chip.closeIconTint = ColorStateList.valueOf(foreground)
+    }
+
+    companion object {
+        private const val KEY_MANGA_IDS = "manga_ids"
+        private const val DEFAULT_POSITION = 0
+        private const val STATIC_TAG_EDITOR_CHILDREN = 2
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/BulkEditMangaDialog.kt
@@ -50,7 +50,8 @@ class BulkEditMangaDialog : DialogController {
 
         val statusEntries =
             listOf(activity!!.getString(R.string.bulk_edit_default)) +
-                resources!!.getStringArray(R.array.manga_statuses).toList()
+                resources!!.getStringArray(R.array.manga_statuses).toList() +
+                activity!!.getString(R.string.source_default)
         binding.mangaStatus.setEntries(statusEntries)
         val initialStatusPosition =
             initialState.commonStatus
@@ -60,7 +61,8 @@ class BulkEditMangaDialog : DialogController {
 
         val seriesTypeEntries =
             listOf(activity!!.getString(R.string.bulk_edit_default)) +
-                resources!!.getStringArray(R.array.series_type).toList()
+                resources!!.getStringArray(R.array.series_type).toList() +
+                activity!!.getString(R.string.source_default)
         binding.seriesType.setEntries(seriesTypeEntries)
         val initialSeriesTypePosition = initialState.commonSeriesType ?: DEFAULT_POSITION
         binding.seriesType.setSelection(initialSeriesTypePosition)
@@ -75,24 +77,30 @@ class BulkEditMangaDialog : DialogController {
             .setNegativeButton(android.R.string.cancel, null)
             .setPositiveButton(R.string.save) { _, _ ->
                 val selectedStatusPosition = binding.mangaStatus.selectedPosition
+                val resetStatus = selectedStatusPosition == statusEntries.lastIndex
                 val status =
                     selectedStatusPosition
                         .takeIf {
                             it != DEFAULT_POSITION &&
+                                it != statusEntries.lastIndex &&
                                 it != initialStatusPosition
                         }?.minus(1)
 
                 val selectedSeriesTypePosition = binding.seriesType.selectedPosition
+                val resetSeriesType = selectedSeriesTypePosition == seriesTypeEntries.lastIndex
                 val seriesType =
                     selectedSeriesTypePosition.takeIf {
                         it != DEFAULT_POSITION &&
+                            it != seriesTypeEntries.lastIndex &&
                             it != initialSeriesTypePosition
                     }
 
                 libraryController.presenter.bulkEditManga(
                     mangaIds = mangaIds.toList(),
                     status = status,
+                    resetStatus = resetStatus,
                     seriesType = seriesType,
+                    resetSeriesType = resetSeriesType,
                     tagsToAdd = tagsToAdd,
                     tagsToRemove = tagsToRemove,
                 )

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -2415,7 +2415,9 @@ open class LibraryController(
         val migrationItem = menu.findItem(R.id.action_migrate)
         val shareItem = menu.findItem(R.id.action_share)
         val categoryItem = menu.findItem(R.id.action_move_to_category)
+        val editItem = menu.findItem(R.id.action_edit_manga)
         categoryItem.isVisible = presenter.allCategories.size > 1
+        editItem.isVisible = selectedMangas.isNotEmpty() && selectedMangas.all { !it.isLocal() }
         migrationItem.isVisible = selectedMangas.any { it.source != LocalSource.ID }
         shareItem.isVisible = migrationItem.isVisible
         if (count == 0) {
@@ -2433,6 +2435,12 @@ open class LibraryController(
     ): Boolean {
         when (item.itemId) {
             R.id.action_move_to_category -> showChangeMangaCategoriesSheet()
+            R.id.action_edit_manga -> {
+                val ids = selectedMangas.mapNotNull { it.id }.distinct().toLongArray()
+                if (ids.isNotEmpty()) {
+                    BulkEditMangaDialog(this, ids).showDialog(router)
+                }
+            }
             R.id.action_share -> shareManga()
             R.id.action_delete -> {
                 val options =

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -1256,9 +1256,7 @@ class LibraryPresenter(
                 BulkSharedTag(
                     name = tag,
                     isCustom = isCustom,
-                    // A shared tag is only removable when it is a custom addition on every
-                    // selected series. Source-provided tags still appear, but are protected.
-                    removable = isCustom,
+                    removable = true,
                 )
             }
 
@@ -1296,15 +1294,11 @@ class LibraryPresenter(
                     var genreChanged = false
                     var changed = false
 
-                    // Re-check source protection here as well as in the UI. This prevents a
-                    // source-provided tag from being removed even if the dialog state is stale.
-                    val removableForManga = customTagsForManga(manga)
                     if (cleanRemovals.isNotEmpty()) {
                         val nextGenres =
                             genres.filterNot { current ->
                                 cleanRemovals.any { remove ->
-                                    remove.equals(current, ignoreCase = true) &&
-                                        removableForManga.any { it.equals(current, ignoreCase = true) }
+                                    remove.equals(current, ignoreCase = true)
                                 }
                             }
                         if (!sameTags(genres, nextGenres)) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.Manga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.download.DownloadManager
+import eu.kanade.tachiyomi.data.library.CustomMangaManager
 import eu.kanade.tachiyomi.data.preference.DelayedLibrarySuggestionsJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.preference.minusAssign
@@ -58,6 +59,18 @@ import java.util.concurrent.TimeUnit
 import kotlin.math.roundToInt
 import kotlin.random.Random
 
+data class BulkEditState(
+    val commonStatus: Int?,
+    val commonSeriesType: Int?,
+    val sharedTags: List<BulkSharedTag>,
+)
+
+data class BulkSharedTag(
+    val name: String,
+    val isCustom: Boolean,
+    val removable: Boolean,
+)
+
 /**
  * Presenter of [LibraryController].
  */
@@ -69,6 +82,7 @@ class LibraryPresenter(
     private val downloadManager: DownloadManager = Injekt.get(),
     private val chapterFilter: ChapterFilter = Injekt.get(),
     private val trackManager: TrackManager = Injekt.get(),
+    private val customMangaManager: CustomMangaManager = Injekt.get(),
 ) : BaseCoroutinePresenter<LibraryController>() {
     private val context = preferences.context
     private val viewContext
@@ -1208,6 +1222,199 @@ class LibraryPresenter(
             }
         }
     }
+
+    fun getBulkEditState(mangaIds: List<Long>): BulkEditState {
+        val mangas = getBulkEditMangas(mangaIds)
+        if (mangas.isEmpty()) {
+            return BulkEditState(null, null, emptyList())
+        }
+
+        val commonStatus = mangas.map { it.status }.distinct().singleOrNull()
+        val commonSeriesType =
+            mangas
+                .map { it.seriesType(sourceManager = sourceManager) }
+                .distinct()
+                .singleOrNull()
+
+        val sharedTagNames =
+            mangas
+                .first()
+                .getGenres()
+                .orEmpty()
+                .filter { tag ->
+                    mangas.drop(1).all { manga ->
+                        manga.getGenres().orEmpty().any { it.equals(tag, ignoreCase = true) }
+                    }
+                }.distinctBy { it.lowercase(Locale.ROOT) }
+
+        val sharedTags =
+            sharedTagNames.map { tag ->
+                val isCustom =
+                    mangas.all { manga ->
+                        customTagsForManga(manga).any { it.equals(tag, ignoreCase = true) }
+                    }
+                BulkSharedTag(
+                    name = tag,
+                    isCustom = isCustom,
+                    // A shared tag is only removable when it is a custom addition on every
+                    // selected series. Source-provided tags still appear, but are protected.
+                    removable = isCustom,
+                )
+            }
+
+        return BulkEditState(commonStatus, commonSeriesType, sharedTags)
+    }
+
+    fun bulkEditManga(
+        mangaIds: List<Long>,
+        status: Int?,
+        seriesType: Int?,
+        tagsToAdd: List<String>,
+        tagsToRemove: List<String>,
+    ) {
+        val mangas = getBulkEditMangas(mangaIds)
+        if (mangas.isEmpty()) return
+
+        val cleanAdds =
+            tagsToAdd
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .distinctBy { it.lowercase(Locale.ROOT) }
+        val cleanRemovals =
+            tagsToRemove
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .distinctBy { it.lowercase(Locale.ROOT) }
+
+        presenterScope.launchIO {
+            val updates =
+                mangas.mapNotNull { manga ->
+                    val existing = customMangaManager.getCustomInfo(manga)
+                    var genres = manga.getGenres().orEmpty()
+                    var genreChanged = false
+                    var changed = false
+
+                    // Re-check source protection here as well as in the UI. This prevents a
+                    // source-provided tag from being removed even if the dialog state is stale.
+                    val removableForManga = customTagsForManga(manga)
+                    if (cleanRemovals.isNotEmpty()) {
+                        val nextGenres =
+                            genres.filterNot { current ->
+                                cleanRemovals.any { remove ->
+                                    remove.equals(current, ignoreCase = true) &&
+                                        removableForManga.any { it.equals(current, ignoreCase = true) }
+                                }
+                            }
+                        if (!sameTags(genres, nextGenres)) {
+                            genres = nextGenres
+                            genreChanged = true
+                            changed = true
+                        }
+                    }
+
+                    cleanAdds.forEach { tag ->
+                        if (genres.none { it.equals(tag, ignoreCase = true) }) {
+                            genres = genres + tag
+                            genreChanged = true
+                            changed = true
+                        }
+                    }
+
+                    if (seriesType != null) {
+                        val oldType = manga.seriesType(sourceManager = sourceManager)
+                        val nextGenres = setSeriesType(manga, seriesType, genres)
+                        if (!sameTags(genres, nextGenres)) {
+                            genres = nextGenres
+                            genreChanged = true
+                            changed = true
+                        }
+                        if (oldType != seriesType) {
+                            manga.viewer_flags = -1
+                            db.updateViewerFlags(manga).executeAsBlocking()
+                        }
+                    }
+
+                    val statusOverride =
+                        if (status != null) {
+                            status.takeUnless { it == manga.originalStatus }
+                        } else {
+                            existing?.status
+                        }
+                    if (status != null && statusOverride != existing?.status) {
+                        changed = true
+                    }
+
+                    if (!changed) return@mapNotNull null
+
+                    CustomMangaManager.MangaJson(
+                        id = manga.id,
+                        title = existing?.title,
+                        author = existing?.author,
+                        artist = existing?.artist,
+                        description = existing?.description,
+                        genre = if (genreChanged) customGenreOverride(manga, genres) else existing?.genre,
+                        status = statusOverride,
+                    )
+                }
+
+            if (updates.isNotEmpty()) {
+                customMangaManager.saveMangaInfo(updates)
+                withUIContext { updateManga() }
+            }
+        }
+    }
+
+    private fun getBulkEditMangas(mangaIds: List<Long>): List<Manga> {
+        val ids = mangaIds.toSet()
+        return allLibraryItems
+            .asSequence()
+            .map { it.manga }
+            .filter { it.id?.let(ids::contains) == true && !it.isLocal() }
+            .distinctBy { it.id }
+            .toList()
+    }
+
+    private fun customTagsForManga(manga: Manga): List<String> {
+        val customGenres = customMangaManager.getCustomInfo(manga)?.genre?.toList().orEmpty()
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        return customGenres.filter { custom ->
+            originalGenres.none { it.equals(custom, ignoreCase = true) }
+        }
+    }
+
+    private fun customGenreOverride(
+        manga: Manga,
+        genres: List<String>,
+    ): Array<String>? {
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        return genres
+            .takeUnless { sameTags(it, originalGenres) }
+            ?.toTypedArray()
+    }
+
+    private fun setSeriesType(
+        manga: Manga,
+        seriesType: Int,
+        genres: List<String>,
+    ): List<String> {
+        val tags = genres.toMutableList()
+        tags.removeAll { manga.isSeriesTag(it) }
+        when (seriesType) {
+            Manga.TYPE_MANGA -> tags.add("Manga")
+            Manga.TYPE_MANHUA -> tags.add("Manhua")
+            Manga.TYPE_MANHWA -> tags.add("Manhwa")
+            Manga.TYPE_COMIC -> tags.add("Comic")
+            Manga.TYPE_WEBTOON -> tags.add("Webtoon")
+        }
+        return tags
+    }
+
+    private fun sameTags(
+        first: List<String>,
+        second: List<String>,
+    ): Boolean =
+        first.size == second.size &&
+            first.zip(second).all { (a, b) -> a.equals(b, ignoreCase = true) }
 
     /** Called when Library Service updates a manga, update the item as well */
     fun updateManga() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -1431,6 +1431,7 @@ class LibraryPresenter(
         seriesType: Int,
         genres: List<String>,
     ): List<String> {
+        if (manga.seriesType(sourceManager = sourceManager) == seriesType) return genres
         val tags = genres.toMutableList()
         tags.removeAll { manga.isSeriesTag(it) }
         when (seriesType) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -63,6 +63,7 @@ data class BulkEditState(
     val commonStatus: Int?,
     val commonSeriesType: Int?,
     val sharedTags: List<BulkSharedTag>,
+    val sourceSharedTags: List<BulkSharedTag>,
 )
 
 data class BulkSharedTag(
@@ -1226,7 +1227,7 @@ class LibraryPresenter(
     fun getBulkEditState(mangaIds: List<Long>): BulkEditState {
         val mangas = getBulkEditMangas(mangaIds)
         if (mangas.isEmpty()) {
-            return BulkEditState(null, null, emptyList())
+            return BulkEditState(null, null, emptyList(), emptyList())
         }
 
         val commonStatus = mangas.map { it.status }.distinct().singleOrNull()
@@ -1259,8 +1260,19 @@ class LibraryPresenter(
                     removable = true,
                 )
             }
+        val sourceSharedTags =
+            mangas
+                .first()
+                .getOriginalGenres()
+                .orEmpty()
+                .filter { tag ->
+                    mangas.drop(1).all { manga ->
+                        manga.getOriginalGenres().orEmpty().any { it.equals(tag, ignoreCase = true) }
+                    }
+                }.distinctBy { it.lowercase(Locale.ROOT) }
+                .map { tag -> BulkSharedTag(tag, isCustom = false, removable = true) }
 
-        return BulkEditState(commonStatus, commonSeriesType, sharedTags)
+        return BulkEditState(commonStatus, commonSeriesType, sharedTags, sourceSharedTags)
     }
 
     fun bulkEditManga(
@@ -1269,6 +1281,7 @@ class LibraryPresenter(
         resetStatus: Boolean,
         seriesType: Int?,
         resetSeriesType: Boolean,
+        resetTags: Boolean,
         tagsToAdd: List<String>,
         tagsToRemove: List<String>,
     ) {
@@ -1293,6 +1306,15 @@ class LibraryPresenter(
                     var genres = manga.getGenres().orEmpty()
                     var genreChanged = false
                     var changed = false
+
+                    if (resetTags) {
+                        val sourceGenres = manga.getOriginalGenres().orEmpty()
+                        if (!sameTags(genres, sourceGenres) || existing?.genre != null) {
+                            genres = sourceGenres
+                            genreChanged = true
+                            changed = true
+                        }
+                    }
 
                     if (cleanRemovals.isNotEmpty()) {
                         val nextGenres =
@@ -1382,7 +1404,12 @@ class LibraryPresenter(
     }
 
     private fun customTagsForManga(manga: Manga): List<String> {
-        val customGenres = customMangaManager.getCustomInfo(manga)?.genre?.toList().orEmpty()
+        val customGenres =
+            customMangaManager
+                .getCustomInfo(manga)
+                ?.genre
+                ?.toList()
+                .orEmpty()
         val originalGenres = manga.getOriginalGenres().orEmpty()
         return customGenres.filter { custom ->
             originalGenres.none { it.equals(custom, ignoreCase = true) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryPresenter.kt
@@ -1268,7 +1268,9 @@ class LibraryPresenter(
     fun bulkEditManga(
         mangaIds: List<Long>,
         status: Int?,
+        resetStatus: Boolean,
         seriesType: Int?,
+        resetSeriesType: Boolean,
         tagsToAdd: List<String>,
         tagsToRemove: List<String>,
     ) {
@@ -1320,27 +1322,38 @@ class LibraryPresenter(
                         }
                     }
 
-                    if (seriesType != null) {
+                    if (resetSeriesType || seriesType != null) {
                         val oldType = manga.seriesType(sourceManager = sourceManager)
-                        val nextGenres = setSeriesType(manga, seriesType, genres)
+                        val targetType =
+                            if (resetSeriesType) {
+                                manga.seriesType(useOriginalTags = true, sourceManager = sourceManager)
+                            } else {
+                                seriesType!!
+                            }
+                        val nextGenres =
+                            if (resetSeriesType) {
+                                restoreDefaultSeriesType(manga, genres)
+                            } else {
+                                setSeriesType(manga, targetType, genres)
+                            }
                         if (!sameTags(genres, nextGenres)) {
                             genres = nextGenres
                             genreChanged = true
                             changed = true
                         }
-                        if (oldType != seriesType) {
+                        if (oldType != targetType) {
                             manga.viewer_flags = -1
                             db.updateViewerFlags(manga).executeAsBlocking()
                         }
                     }
 
                     val statusOverride =
-                        if (status != null) {
-                            status.takeUnless { it == manga.originalStatus }
-                        } else {
-                            existing?.status
+                        when {
+                            resetStatus -> null
+                            status != null -> status.takeUnless { it == manga.originalStatus }
+                            else -> existing?.status
                         }
-                    if (status != null && statusOverride != existing?.status) {
+                    if ((resetStatus || status != null) && statusOverride != existing?.status) {
                         changed = true
                     }
 
@@ -1406,6 +1419,31 @@ class LibraryPresenter(
             Manga.TYPE_COMIC -> tags.add("Comic")
             Manga.TYPE_WEBTOON -> tags.add("Webtoon")
         }
+        return tags
+    }
+
+    private fun restoreDefaultSeriesType(
+        manga: Manga,
+        genres: List<String>,
+    ): List<String> {
+        val originalGenres = manga.getOriginalGenres().orEmpty()
+        val currentNonSeriesTags = genres.filterNot { manga.isSeriesTag(it) }
+        val originalNonSeriesTags = originalGenres.filterNot { manga.isSeriesTag(it) }
+
+        // If series type is the only tag-level override, restore the exact source list so
+        // the custom genre override can be removed completely.
+        if (sameTags(currentNonSeriesTags, originalNonSeriesTags)) {
+            return originalGenres
+        }
+
+        val tags = currentNonSeriesTags.toMutableList()
+        originalGenres
+            .filter { manga.isSeriesTag(it) }
+            .forEach { originalTag ->
+                if (tags.none { it.equals(originalTag, ignoreCase = true) }) {
+                    tags += originalTag
+                }
+            }
         return tags
     }
 

--- a/app/src/main/res/layout/bulk_edit_manga_dialog.xml
+++ b/app/src/main/res/layout/bulk_edit_manga_dialog.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp">
+
+        <eu.kanade.tachiyomi.widget.MaterialSpinnerView
+            android:id="@+id/manga_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="18dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="6dp"
+            app:title="@string/status" />
+
+        <eu.kanade.tachiyomi.widget.MaterialSpinnerView
+            android:id="@+id/series_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="18dp"
+            android:layout_marginEnd="16dp"
+            app:title="@string/series_type" />
+
+        <com.google.android.material.textview.MaterialTextView
+            style="?textAppearanceTitleSmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginEnd="20dp"
+            android:text="@string/shared_tags" />
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/shared_tags"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/add_tag_chip"
+                style="@style/Widget.Tachiyomi.Chip.AddTag"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/add_tag" />
+
+            <eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText
+                android:id="@+id/add_tag_edit_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:hint="@string/add_tag"
+                android:imeOptions="actionDone"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:maxLines="1"
+                android:visibility="gone" />
+        </com.google.android.material.chip.ChipGroup>
+    </LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/bulk_edit_manga_dialog.xml
+++ b/app/src/main/res/layout/bulk_edit_manga_dialog.xml
@@ -64,5 +64,14 @@
                 android:maxLines="1"
                 android:visibility="gone" />
         </com.google.android.material.chip.ChipGroup>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/reset_tags"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/reset_tags"
+            android:textAllCaps="false" />
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/menu/library_selection.xml
+++ b/app/src/main/res/menu/library_selection.xml
@@ -22,6 +22,11 @@
         app:showAsAction="ifRoom" />
 
     <item
+        android:id="@+id/action_edit_manga"
+        android:title="@string/edit"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_download_unread"
         android:title="@string/download_unread"
         app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -606,6 +606,8 @@
     <string name="sort_by_chapter_number">Sort by chapter number</string>
     <string name="newest_first">Newest to oldest</string>
     <string name="oldest_first">Oldest to newest</string>
+    <string name="shared_tags">Shared tags</string>
+    <string name="bulk_edit_default">Default</string>
     <string name="add_tag">Add tag</string>
     <string name="clear_tags">Clear tags</string>
     <string name="reset_tags">Reset tags</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -608,6 +608,7 @@
     <string name="oldest_first">Oldest to newest</string>
     <string name="shared_tags">Shared tags</string>
     <string name="bulk_edit_default">Default</string>
+    <string name="source_default">Source default</string>
     <string name="add_tag">Add tag</string>
     <string name="clear_tags">Clear tags</string>
     <string name="reset_tags">Reset tags</string>


### PR DESCRIPTION
## Summary

This is a follow-up to the discussion in #1903 and is based directly on the bulk-edit approach you suggested there.

Instead of separate bulk add/remove tag actions, this adds an **Edit** option when selecting manga in the Library and opens a reduced bulk version of the manga edit dialog containing:

* **Status**
* **Series type**
* **Shared tags**

If the selected manga share the same Status or Series type, that value is shown. If they differ, **Default** is shown and leaving it selected makes no change.

Shared tags are the tags currently present on every selected manga. Shared custom tags can be removed, and new tags can be added across the selection.

## Commits

I split this into two commits deliberately.

The **first commit** is the implementation closest to the suggestion from #1903.

The **second commit** only adds **Source default** for Status and Series type, so if you prefer the original behaviour without reset support that commit can simply be dropped/reverted.

**Source default** only resets the selected field for each manga:

* Status - restores that manga's source/original status.
* Series type - restores that manga's original series type while preserving unrelated custom tags.

## Source tags

For now, source-provided tags are shown in Shared tags but aren't removable, while custom-added tags are removable. The two are also given different colours so it's clear which is which.

For source tags, I'm of two minds. One tells me, well, you can already edit that in the individual manga section, so you should be able to here, and if you mess up you can just reset those in individual entries if need be. But another says, yeah, no, probably a bad idea and a pain to individually reset.

If you would rather allow it, I can put that in another separate commit. The implementation already tracks whether a shared tag is custom or source, so enabling source removal is just like changing one thing to true and removing some additional backend safety checks.


## Testing

I've tested the main combinations locally, including:

* single and multiple selections
* common and differing Status/Series type values
* leaving Default selected and confirming no change occurs
* changing and resetting Status/Series type
* preserving unrelated custom tags when resetting Series type
* adding and removing shared custom tags
* duplicate prevention
* mixed source/custom tag cases
* confirming source-provided tags remain protected
* preserving unrelated custom manga information
* repeated edits
* selection remaining highlighted while the dialog is open
* closing and reopening the app after edits

Everything I've tested so far has behaved as expected.

## Considerations

Shared Tags requires comparing the selected manga's metadata when opening the dialog. I haven't noticed any meaningful delay during testing, but very large selections probably involve more work.

I kept the scope limited to Status, Series type and Shared tags to stay close to the original suggestion and avoid making broad accidental metadata changes too easy.

Video below showcasing how to use

https://github.com/user-attachments/assets/c1eb4022-5765-4d1a-b317-920df12f19bc